### PR TITLE
LayoutTree의 메모리 해제 개선

### DIFF
--- a/Sources/SwiftLayout/Layout/LayoutTree.swift
+++ b/Sources/SwiftLayout/Layout/LayoutTree.swift
@@ -8,11 +8,19 @@
 import Foundation
 import UIKit
 
-public class LayoutTree: Layoutable {
+public class LayoutTree: Layoutable, CustomDebugStringConvertible {
     
     internal init(view: UIView, subtree: [LayoutTree] = []) {
         self.view = view
         self.subtrees = subtree
+    }
+    
+    deinit {
+        #if !DEBUG
+        print("<====DEINIT LAYOUT_TREE=====>")
+        print(self.debugDescription)
+        print("<\\===DEINIT LAYOUT_TREE=====>")
+        #endif
     }
     
     let view: UIView
@@ -35,4 +43,17 @@ public class LayoutTree: Layoutable {
         self
     }
     
+    public var debugDescription: String {
+        var tag = TagDescriptor(view).debugDescription
+        if !subtrees.isEmpty {
+            let subs = subtrees.map(\.debugDescription)
+            let count = tag.count
+            let elementPrefix = " ".repeated(count + 3)
+            let parenthesisPrefix = " ".repeated(count)
+            tag += " {\n"
+            tag += subs.map(elementPrefix+).joined(separator: "\n")
+            tag += "\n" + parenthesisPrefix + " }\n"
+        }
+        return tag
+    }
 }

--- a/Sources/SwiftLayout/Layout/LayoutTree.swift
+++ b/Sources/SwiftLayout/Layout/LayoutTree.swift
@@ -16,11 +16,12 @@ public class LayoutTree: Layoutable, CustomDebugStringConvertible {
     }
     
     deinit {
-        #if !DEBUG
+        #if DEBUG
         print("<====DEINIT LAYOUT_TREE=====>")
         print(self.debugDescription)
         print("<\\===DEINIT LAYOUT_TREE=====>")
         #endif
+        deactive()
     }
     
     let view: UIView
@@ -37,6 +38,15 @@ public class LayoutTree: Layoutable, CustomDebugStringConvertible {
             $0.active()
         })
         return self
+    }
+    
+    public func deactive() {
+        subtrees.forEach({ $0.deactiveChild() })
+    }
+    
+    public func deactiveChild() {
+        view.removeFromSuperview()
+        subtrees.forEach({ $0.deactiveChild() })
     }
     
     public func layoutTree(in parent: UIView) -> LayoutTree {

--- a/Sources/SwiftLayout/Layout/Layoutable.swift
+++ b/Sources/SwiftLayout/Layout/Layoutable.swift
@@ -11,5 +11,12 @@ import UIKit
 public protocol Layoutable {
     @discardableResult
     func active() -> Layoutable
+    func deactive()
+    func deactiveChild()
     func layoutTree(in parent: UIView) -> LayoutTree
+}
+
+extension Layoutable {
+    public func deactive() {}
+    public func deactiveChild() {}
 }

--- a/Sources/SwiftLayout/Util/Operators.swift
+++ b/Sources/SwiftLayout/Util/Operators.swift
@@ -1,0 +1,16 @@
+//
+//  Operators.swift
+//  
+//
+//  Created by maylee on 2022/01/30.
+//
+
+import Foundation
+
+postfix operator +
+
+postfix func +<S: StringProtocol>(lhs: S) -> (_ rhs: S) -> String {
+    { rhs in
+        lhs.appending(rhs)
+    }
+}

--- a/Sources/SwiftLayout/Util/String+Extension.swift
+++ b/Sources/SwiftLayout/Util/String+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  String+Extension.swift
+//  
+//
+//  Created by maylee on 2022/01/30.
+//
+
+import Foundation
+
+extension String {
+    func repeated(_ count: Int) -> String {
+        Array(repeating: self, count: count).joined()
+    }
+}

--- a/Sources/SwiftLayout/Util/TagDescriptor.swift
+++ b/Sources/SwiftLayout/Util/TagDescriptor.swift
@@ -1,0 +1,30 @@
+//
+//  Addressable.swift
+//  
+//
+//  Created by oozoofrog on 2022/01/30.
+//
+
+import Foundation
+import UIKit
+
+struct TagDescriptor<Value>: CustomDebugStringConvertible where Value: UIAccessibilityIdentification {
+    internal init(_ value: Value) {
+        self.value = value
+    }
+    
+    let value: Value
+    
+    var identifier: String {
+        if let identifier = value.accessibilityIdentifier {
+            return identifier
+        } else {
+            return Unmanaged<Value>.passUnretained(value).toOpaque().debugDescription
+        }
+    }
+    
+    var debugDescription: String {
+        "\(type(of: self))(\(identifier))"
+    }
+    
+}

--- a/Tests/SwiftLayoutTests/SwiftLayoutTests.swift
+++ b/Tests/SwiftLayoutTests/SwiftLayoutTests.swift
@@ -25,9 +25,13 @@ final class SwiftLayoutTests: XCTestCase {
     func testLayoutTreeBuild() {
         let tree = root {
             yellow
-        }
+        }.active()
         
         XCTAssertTrue(tree is LayoutTree, "\(type(of: tree)) is not LayoutTree")
+        XCTAssertEqual(yellow.superview, root)
+        context("tree가 사라지면 view hierarchy도 사라진다") {
+            XCTAssertNil(yellow.superview)
+        }
     }
     
     func testLayoutContainableDoNotContain() {

--- a/Tests/SwiftLayoutTests/SwiftLayoutTests.swift
+++ b/Tests/SwiftLayoutTests/SwiftLayoutTests.swift
@@ -23,14 +23,31 @@ final class SwiftLayoutTests: XCTestCase {
     }
     
     func testLayoutTreeBuild() {
-        let tree = root {
-            yellow
-        }.active()
-        
-        XCTAssertTrue(tree is LayoutTree, "\(type(of: tree)) is not LayoutTree")
-        XCTAssertEqual(yellow.superview, root)
-        context("tree가 사라지면 view hierarchy도 사라진다") {
-            XCTAssertNil(yellow.superview)
+        context("Layoutable.active() 호출은") {
+            let tree = root {
+                yellow
+            }.active()
+            context("LayoutTree를 반환한다.") {
+                XCTAssertTrue(tree is LayoutTree, "\(type(of: tree)) is not LayoutTree")
+                XCTAssertEqual(yellow.superview, root)
+            }
+        }
+        context("LayoutTree의 인스턴스를 보관하지 않으면") {
+            context("LayoutTree가 deinit될 때 view hierarchy도 사라진다") {
+                XCTAssertNil(yellow.superview)
+            }
+        }
+        context("Layoutable 생성 후") {
+            let tree = root {
+                yellow
+            }.active()
+            context("deactive()를 호출하면 ") {
+                tree.deactive()
+                context("LayoutTree의 view hierarchy를 모두 제거한다.") {
+                    XCTAssertTrue(tree is LayoutTree, "\(type(of: tree)) is not LayoutTree")
+                    XCTAssertEqual(yellow.superview, root)
+                }
+            }
         }
     }
     

--- a/Tests/SwiftLayoutTests/SwiftLayoutTests.swift
+++ b/Tests/SwiftLayoutTests/SwiftLayoutTests.swift
@@ -45,7 +45,7 @@ final class SwiftLayoutTests: XCTestCase {
                 tree.deactive()
                 context("LayoutTree의 view hierarchy를 모두 제거한다.") {
                     XCTAssertTrue(tree is LayoutTree, "\(type(of: tree)) is not LayoutTree")
-                    XCTAssertEqual(yellow.superview, root)
+                    XCTAssertNil(yellow.superview)
                 }
             }
         }


### PR DESCRIPTION
LayoutTree의 메모리 해제는 들고 있는 superview와 subview의 연결을 끊는다