### PR TITLE
weak view reference

### DIFF
--- a/Sources/SwiftLayout/Anchors/AnchorsLayout.swift
+++ b/Sources/SwiftLayout/Anchors/AnchorsLayout.swift
@@ -15,7 +15,7 @@ public final class AnchorsLayout<C>: ViewContainableLayout where C: Constraint {
         self.constraint = constraint
     }
     
-    public let view: UIView
+    public weak var view: UIView?
     var constraint: C
     
     public var layouts: [Layout] = []
@@ -26,10 +26,15 @@ public final class AnchorsLayout<C>: ViewContainableLayout where C: Constraint {
     }
     
     public func attachSuperview(_ superview: UIView?) {
-        superview?.addSubview(self.view)
-        self.view.translatesAutoresizingMaskIntoConstraints = false
+        guard let view = view else {
+            return
+        }
+        if let superview = superview {
+            superview.addSubview(view)
+        }
+        view.translatesAutoresizingMaskIntoConstraints = false
         for layout in layouts {
-            layout.attachSuperview(self.view)
+            layout.attachSuperview(view)
         }
         self.constraints = constraint.constraints(item: view, toItem: superview)
     }

--- a/Sources/SwiftLayout/Layout/Extension/Layout+Description.swift
+++ b/Sources/SwiftLayout/Layout/Extension/Layout+Description.swift
@@ -21,6 +21,7 @@ extension CustomDebugStringConvertible where Self: ContainableLayout {
 
 extension CustomDebugStringConvertible where Self: ViewContainableLayout {
     public var debugDescription: String {
+        guard let view = view else { return "" }
         if layouts.isEmpty {
             return view.tagDescription
         } else {

--- a/Sources/SwiftLayout/Layout/Layouts/ViewLayout.swift
+++ b/Sources/SwiftLayout/Layout/Layouts/ViewLayout.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 public struct ViewLayout<L>: ViewContainableLayout where L: ContainableLayout {
-    internal(set) public var view: UIView
+    internal(set) public weak var view: UIView?
     var layoutable: L
     
     public var layouts: [Layout] {

--- a/Sources/SwiftLayout/Layout/Protocol/ViewContainableLayout.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/ViewContainableLayout.swift
@@ -9,19 +9,21 @@ import Foundation
 import UIKit
 
 public protocol ViewContainableLayout: ContainableLayout {
-    var view: UIView { get }
+    var view: UIView? { get }
 }
 
 public extension ViewContainableLayout {
     func attachSuperview(_ superview: UIView?) {
-        superview?.addSubview(self.view)
+        if let superview = superview, let view = view {
+            superview.addSubview(view)
+        }
         for layout in layouts {
             layout.attachSuperview(self.view)
         }
     }
     func detachFromSuperview(_ superview: UIView?) {
-        if let superview = superview, self.view.superview == superview {
-            self.view.removeFromSuperview()
+        if let superview = superview, self.view?.superview == superview {
+            self.view?.removeFromSuperview()
         }
         for layout in layouts {
             layout.detachFromSuperview(self.view)


### PR DESCRIPTION
ViewLayout has now weak reference of view.

but this should be losing init views in layout like below

```swift
root {
  UIView() // view
}
```

Layout no more contain UIView() in layout.