### PR TITLE
elements of layout after activation become flatten

### DIFF
--- a/Sources/SwiftLayout/Anchors/Anchors.swift
+++ b/Sources/SwiftLayout/Anchors/Anchors.swift
@@ -59,6 +59,7 @@ public final class Anchors: Constraint {
     public func lessThanOrEqualTo(_ toItem: NSObject? = nil, attribute: NSLayoutConstraint.Attribute? = nil) -> Self {
         to(.lessThanOrEqual, to: .init(item: toItem, attribute: attribute, constant: .zero))
     }
+    
     public func equalTo(_ toItem: NSObject? = nil, attribute: NSLayoutConstraint.Attribute? = nil, constant: CGFloat) -> Self {
         to(.equal, to: .init(item: toItem, attribute: attribute, constant: constant))
     }

--- a/Sources/SwiftLayout/Anchors/Anchors.swift
+++ b/Sources/SwiftLayout/Anchors/Anchors.swift
@@ -26,10 +26,6 @@ public final class Anchors: Constraint {
     
     var items: [Item] = []
     
-    public var hashable: AnyHashable {
-        AnyHashable(items)
-    }
-    
     public func setConstant(_ constant: CGFloat) -> Self {
         for i in 0..<items.count {
             items[i].constant = constant

--- a/Sources/SwiftLayout/Anchors/AnchorsLayout.swift
+++ b/Sources/SwiftLayout/Anchors/AnchorsLayout.swift
@@ -54,18 +54,12 @@ public final class AnchorsLayout<C>: ViewContainableLayout where C: Constraint {
             layout.prepareConstraints()
         }
     }
+    
     public func activeConstraints() {
         NSLayoutConstraint.activate(self.constraints)
         for layout in layouts {
             layout.activeConstraints()
         }
-    }
-    
-    public func deactiveConstraints() {
-        for layout in layouts {
-            layout.deactiveConstraints()
-        }
-        NSLayoutConstraint.deactivate(self.constraints)
     }
     
     public func subviews<L>(@LayoutBuilder _ build: () -> L) -> Self where L: Layout {

--- a/Sources/SwiftLayout/Anchors/Extension/NSLayoutConstraint+Constraint.swift
+++ b/Sources/SwiftLayout/Anchors/Extension/NSLayoutConstraint+Constraint.swift
@@ -12,8 +12,4 @@ extension NSLayoutConstraint: Constraint {
     public func constraints(item: NSObject, toItem: NSObject?) -> [NSLayoutConstraint] {
         [self]
     }
-    
-    public var hashable: AnyHashable {
-        AnyHashable(self)
-    }
 }

--- a/Sources/SwiftLayout/Anchors/Protocol/Constraint.swift
+++ b/Sources/SwiftLayout/Anchors/Protocol/Constraint.swift
@@ -10,7 +10,6 @@ import UIKit
 
 public protocol Constraint {
     func constraints(item: NSObject, toItem: NSObject?) -> [NSLayoutConstraint]
-    var hashable: AnyHashable { get }
 }
 
 extension Array: Constraint where Element == Constraint {
@@ -18,8 +17,5 @@ extension Array: Constraint where Element == Constraint {
         flatMap { constraint in
             constraint.constraints(item: item, toItem: toItem)
         }
-    }
-    public var hashable: AnyHashable {
-        AnyHashable(map(\.hashable))
     }
 }

--- a/Sources/SwiftLayout/Building/LayoutBuilding.swift
+++ b/Sources/SwiftLayout/Building/LayoutBuilding.swift
@@ -22,12 +22,11 @@ public extension LayoutBuilding where Self: NSObject {
         let layout: some Layout = self.layout
         
         if let deactivatable = self.deactivatable as? Deactivation {
-            guard deactivatable.isNew(layout) else { return }
-            self.deactivatable?.deactive()
-            self.deactivatable = nil
+            deactivatable.updateLayout(layout)
+        } else {
+            self.deactivatable = Deactivation(layout)
         }
         
-        self.deactivatable = layout.active()
     }
     
 }

--- a/Sources/SwiftLayout/Layout/Extension/Layout+Description.swift
+++ b/Sources/SwiftLayout/Layout/Extension/Layout+Description.swift
@@ -21,7 +21,6 @@ extension CustomDebugStringConvertible where Self: ContainableLayout {
 
 extension CustomDebugStringConvertible where Self: ViewContainableLayout {
     public var debugDescription: String {
-        guard let view = self.view else { return "" }
         if layouts.isEmpty {
             return view.tagDescription
         } else {

--- a/Sources/SwiftLayout/Layout/Extension/Optional+Layout.swift
+++ b/Sources/SwiftLayout/Layout/Extension/Optional+Layout.swift
@@ -10,12 +10,20 @@ import UIKit
 
 extension Optional: Layout where Wrapped: Layout {
     
-    public func attachSuperview(_ superview: UIView?) {
-        self?.attachSuperview(superview)
+    public func prepareSuperview(_ superview: UIView?) {
+        self?.prepareSuperview(superview)
     }
     
-    public func detachFromSuperview(_ superview: UIView?) {
-        self?.detachFromSuperview(superview)
+    public func attachSuperview() {
+        self?.attachSuperview()
+    }
+    
+    public func detachFromSuperview() {
+        self?.detachFromSuperview()
+    }
+    
+    public func prepareConstraints() {
+        self?.prepareConstraints()
     }
     
     public func activeConstraints() {
@@ -26,7 +34,4 @@ extension Optional: Layout where Wrapped: Layout {
         self?.deactiveConstraints()
     }
     
-    public var hashable: AnyHashable {
-        AnyHashable(self?.hashable)
-    }
 }

--- a/Sources/SwiftLayout/Layout/Extension/Optional+Layout.swift
+++ b/Sources/SwiftLayout/Layout/Extension/Optional+Layout.swift
@@ -18,20 +18,12 @@ extension Optional: Layout where Wrapped: Layout {
         self?.attachSuperview()
     }
     
-    public func detachFromSuperview() {
-        self?.detachFromSuperview()
-    }
-    
     public func prepareConstraints() {
         self?.prepareConstraints()
     }
     
     public func activeConstraints() {
         self?.activeConstraints()
-    }
-    
-    public func deactiveConstraints() {
-        self?.deactiveConstraints()
     }
     
 }

--- a/Sources/SwiftLayout/Layout/Extension/UIView+Layout.swift
+++ b/Sources/SwiftLayout/Layout/Extension/UIView+Layout.swift
@@ -16,13 +16,9 @@ extension Layout where Self: UIView {
     
     public func prepareSuperview(_ superview: UIView?) {}
     public func attachSuperview() {}
-    public func detachFromSuperview() {
-        removeFromSuperview()
-    }
     
     public func prepareConstraints() {}
     public func activeConstraints() {}
-    public func deactiveConstraints() {}
     
 }
 

--- a/Sources/SwiftLayout/Layout/Extension/UIView+Layout.swift
+++ b/Sources/SwiftLayout/Layout/Extension/UIView+Layout.swift
@@ -14,21 +14,16 @@ extension Layout where Self: UIView {
         ViewLayout(view: self, layoutable: build())
     }
     
-    public func attachSuperview(_ superview: UIView?) {
-        superview?.addSubview(self)
-    }
-    
-    public func detachFromSuperview(_ superview: UIView?) {
-        guard self.superview == superview else { return }
+    public func prepareSuperview(_ superview: UIView?) {}
+    public func attachSuperview() {}
+    public func detachFromSuperview() {
         removeFromSuperview()
     }
     
+    public func prepareConstraints() {}
     public func activeConstraints() {}
     public func deactiveConstraints() {}
     
-    public var hashable: AnyHashable {
-        AnyHashable(self)
-    }
 }
 
 extension UIView: Layout {}

--- a/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
+++ b/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
@@ -6,8 +6,12 @@
 //
 
 import Foundation
+import UIKit
 
 final class Deactivation: Deactivable {
+    
+    private var views: [WeakReference<UIView>] = []
+    private var constraints: [WeakReference<NSLayoutConstraint>] = []
     
     init(_ layout: Layout) {
         updateLayout(layout)
@@ -18,6 +22,13 @@ final class Deactivation: Deactivable {
     }
     
     func deactive() {
+        let constraints = constraints.compactMap(\.o)
+        NSLayoutConstraint.deactivate(constraints)
+        let views = views.compactMap(\.o)
+        for view in views {
+            view.removeConstraints(constraints)
+            view.removeFromSuperview()
+        }
     }
     
     func updateLayout(_ layout: Layout) {
@@ -27,4 +38,13 @@ final class Deactivation: Deactivable {
         layout.activeConstraints()
     }
     
+}
+
+extension LayoutFlattening {
+    var viewReferences: Set<WeakReference<UIView>> {
+        Set(layoutViews.map(WeakReference.init))
+    }
+    var constraintReferences: Set<WeakReference<NSLayoutConstraint>> {
+        Set(layoutConstraints.map(WeakReference.init))
+    }
 }

--- a/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
+++ b/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
@@ -27,13 +27,16 @@ final class Deactivation: Deactivable {
         let views = views.compactMap(\.o)
         for view in views {
             view.removeConstraints(constraints)
-            view.removeFromSuperview()
+            if views.contains(where: { $0 == view.superview }) {
+                view.removeFromSuperview()
+            }
         }
     }
     
     func updateLayout(_ layout: Layout) {
         guard let flattening = layout.flattening() else { return }
         guard self.views != flattening.viewReferences || self.constraints != flattening.constraintReferences else { return }
+        deactive()
         self.views = flattening.viewReferences
         layout.attachSuperview()
         self.constraints = flattening.constraintReferences

--- a/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
+++ b/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
@@ -32,22 +32,11 @@ final class Deactivation: Deactivable {
     }
     
     func updateLayout(_ layout: Layout) {
-        guard let flattening = layout as? LayoutFlattening else { return }
-        layout.prepareSuperview(nil)
-        layout.prepareConstraints()
-        self.views = flattening.viewReferences
-        self.constraints = flattening.constraintReferences
+        guard let flattening = layout.flattening() else { return }
         layout.attachSuperview()
         layout.activeConstraints()
+        self.views = flattening.viewReferences
+        self.constraints = flattening.constraintReferences
     }
     
-}
-
-extension LayoutFlattening {
-    var viewReferences: Set<WeakReference<UIView>> {
-        Set(layoutViews.map(WeakReference.init))
-    }
-    var constraintReferences: Set<WeakReference<NSLayoutConstraint>> {
-        Set(layoutConstraints.map(WeakReference.init))
-    }
 }

--- a/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
+++ b/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 final class Deactivation: Deactivable {
-    var layout: Layout
+    
     init(_ layout: Layout) {
-        self.layout = layout
+        updateLayout(layout)
     }
     
     deinit {
@@ -18,10 +18,13 @@ final class Deactivation: Deactivable {
     }
     
     func deactive() {
-        layout.detachFromSuperview()
     }
     
-    func isNew(_ layout: Layout) -> Bool {
-        return self.layout.hashable != layout.hashable
+    func updateLayout(_ layout: Layout) {
+        layout.prepareSuperview(nil)
+        layout.attachSuperview()
+        layout.prepareConstraints()
+        layout.activeConstraints()
     }
+    
 }

--- a/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
+++ b/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
@@ -33,10 +33,11 @@ final class Deactivation: Deactivable {
     
     func updateLayout(_ layout: Layout) {
         guard let flattening = layout.flattening() else { return }
-        layout.attachSuperview()
-        layout.activeConstraints()
+        guard self.views != flattening.viewReferences || self.constraints != flattening.constraintReferences else { return }
         self.views = flattening.viewReferences
+        layout.attachSuperview()
         self.constraints = flattening.constraintReferences
+        layout.activeConstraints()
     }
     
 }

--- a/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
+++ b/Sources/SwiftLayout/Layout/Layouts/Deactivation.swift
@@ -10,8 +10,8 @@ import UIKit
 
 final class Deactivation: Deactivable {
     
-    private var views: [WeakReference<UIView>] = []
-    private var constraints: [WeakReference<NSLayoutConstraint>] = []
+    private var views: Set<WeakReference<UIView>> = []
+    private var constraints: Set<WeakReference<NSLayoutConstraint>> = []
     
     init(_ layout: Layout) {
         updateLayout(layout)
@@ -32,9 +32,12 @@ final class Deactivation: Deactivable {
     }
     
     func updateLayout(_ layout: Layout) {
+        guard let flattening = layout as? LayoutFlattening else { return }
         layout.prepareSuperview(nil)
-        layout.attachSuperview()
         layout.prepareConstraints()
+        self.views = flattening.viewReferences
+        self.constraints = flattening.constraintReferences
+        layout.attachSuperview()
         layout.activeConstraints()
     }
     

--- a/Sources/SwiftLayout/Layout/Layouts/ViewLayout.swift
+++ b/Sources/SwiftLayout/Layout/Layouts/ViewLayout.swift
@@ -32,8 +32,10 @@ public final class ViewLayout<L>: ViewContainableLayout where L: ContainableLayo
     }
     
     public func attachSuperview() {
-        view.translatesAutoresizingMaskIntoConstraints = false
-        superview?.addSubview(view)
+        if let superview = superview {
+            superview.addSubview(view)
+            view.translatesAutoresizingMaskIntoConstraints = false
+        }
         for layout in layouts {
             if let view = layout as? UIView {
                 view.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/SwiftLayout/Layout/Protocol/ContainableLayout.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/ContainableLayout.swift
@@ -13,29 +13,41 @@ public protocol ContainableLayout: Layout {
 }
 
 public extension ContainableLayout {
-    func attachSuperview(_ superview: UIView?) {
+    
+    func prepareSuperview(_ superview: UIView?) {
         for layout in layouts {
-            layout.attachSuperview(superview)
+            layout.prepareSuperview(superview)
         }
     }
-    func detachFromSuperview(_ superview: UIView?) {
+    
+    func attachSuperview() {
         for layout in layouts {
-            layout.detachFromSuperview(superview)
+            layout.attachSuperview()
         }
     }
+    
+    func detachFromSuperview() {
+        for layout in layouts {
+            layout.detachFromSuperview()
+        }
+    }
+    
+    func prepareConstraints() {
+        for layout in layouts {
+            layout.prepareConstraints()
+        }
+    }
+    
     func activeConstraints() {
         for layout in layouts {
             layout.activeConstraints()
         }
     }
+    
     func deactiveConstraints() {
         for layout in layouts {
             layout.deactiveConstraints()
         }
-    }
-    
-    var hashable: AnyHashable {
-        AnyHashable(layouts.map(\.hashable))
     }
 }
 

--- a/Sources/SwiftLayout/Layout/Protocol/ContainableLayout.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/ContainableLayout.swift
@@ -26,12 +26,6 @@ public extension ContainableLayout {
         }
     }
     
-    func detachFromSuperview() {
-        for layout in layouts {
-            layout.detachFromSuperview()
-        }
-    }
-    
     func prepareConstraints() {
         for layout in layouts {
             layout.prepareConstraints()
@@ -41,12 +35,6 @@ public extension ContainableLayout {
     func activeConstraints() {
         for layout in layouts {
             layout.activeConstraints()
-        }
-    }
-    
-    func deactiveConstraints() {
-        for layout in layouts {
-            layout.deactiveConstraints()
         }
     }
 }

--- a/Sources/SwiftLayout/Layout/Protocol/Layout.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/Layout.swift
@@ -9,32 +9,21 @@ import Foundation
 import UIKit
 
 public protocol Layout: CustomDebugStringConvertible {
-    func attachSuperview(_ superview: UIView?)
+    func prepareSuperview(_ superview: UIView?)
     func attachSuperview()
-    func detachFromSuperview(_ superview: UIView?)
     func detachFromSuperview()
    
+    func prepareConstraints()
     func activeConstraints()
     func deactiveConstraints()
-    
-    var hashable: AnyHashable { get }
 }
 
 extension Layout {
     
     public func active() -> Deactivable {
-        attachSuperview()
         return Deactivation(self)
     }
     
-    public func attachSuperview() {
-        attachSuperview(nil)
-        activeConstraints()
-    }
-    public func detachFromSuperview() {
-        deactiveConstraints()
-        detachFromSuperview(nil)
-    }
 }
 
 extension Array: Layout where Self.Element == Layout {}

--- a/Sources/SwiftLayout/Layout/Protocol/Layout.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/Layout.swift
@@ -22,6 +22,16 @@ extension Layout {
         return Deactivation(self)
     }
     
+    func prepare() {
+        prepareSuperview(nil)
+        prepareConstraints()
+    }
+    
+    func flattening() -> LayoutFlattening? {
+        prepare()
+        return self as? LayoutFlattening
+    }
+    
 }
 
 extension Array: Layout where Self.Element == Layout {}

--- a/Sources/SwiftLayout/Layout/Protocol/Layout.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/Layout.swift
@@ -11,11 +11,9 @@ import UIKit
 public protocol Layout: CustomDebugStringConvertible {
     func prepareSuperview(_ superview: UIView?)
     func attachSuperview()
-    func detachFromSuperview()
    
     func prepareConstraints()
     func activeConstraints()
-    func deactiveConstraints()
 }
 
 extension Layout {

--- a/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
@@ -36,3 +36,13 @@ extension LayoutFlattening where Self: ViewContainableLayout {
         return views
     }
 }
+
+
+extension LayoutFlattening {
+    var viewReferences: Set<WeakReference<UIView>> {
+        Set(layoutViews.map(WeakReference.init))
+    }
+    var constraintReferences: Set<WeakReference<NSLayoutConstraint>> {
+        Set(layoutConstraints.map(WeakReference.init))
+    }
+}

--- a/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
@@ -14,3 +14,20 @@ protocol LayoutFlattening {
     var layoutConstraints: [NSLayoutConstraint] { get }
     
 }
+
+extension LayoutFlattening where Self: ContainableLayout {
+    var layoutViews: [UIView] {
+        (layouts as? [LayoutFlattening] ?? []).flatMap(\.layoutViews)
+    }
+    var layoutConstraints: [NSLayoutConstraint] {
+        (layouts as? [LayoutFlattening] ?? []).flatMap(\.layoutConstraints)
+    }
+}
+
+extension LayoutFlattening where Self: ViewContainableLayout {
+    var layoutViews: [UIView] {
+        var views: [UIView] = [view]
+        views.append(contentsOf: (layouts as? [LayoutFlattening] ?? []).flatMap(\.layoutViews))
+        return views
+    }
+}

--- a/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
@@ -20,23 +20,31 @@ extension UIView: LayoutFlattening {
     var layoutConstraints: [NSLayoutConstraint] { [] }
 }
 
-extension LayoutFlattening where Self: ContainableLayout {
+extension Array: LayoutFlattening where Element == Layout {
     var layoutViews: [UIView] {
-        (layouts as? [LayoutFlattening] ?? []).flatMap(\.layoutViews)
+        compactMap({ $0 as? LayoutFlattening }).flatMap(\.layoutViews)
     }
     var layoutConstraints: [NSLayoutConstraint] {
-        (layouts as? [LayoutFlattening] ?? []).flatMap(\.layoutConstraints)
+        compactMap({ $0 as? LayoutFlattening }).flatMap(\.layoutConstraints)
+    }
+}
+
+extension LayoutFlattening where Self: ContainableLayout {
+    var layoutViews: [UIView] {
+        layouts.layoutViews
+    }
+    var layoutConstraints: [NSLayoutConstraint] {
+        layouts.layoutConstraints
     }
 }
 
 extension LayoutFlattening where Self: ViewContainableLayout {
     var layoutViews: [UIView] {
         var views: [UIView] = [view]
-        views.append(contentsOf: (layouts as? [LayoutFlattening] ?? []).flatMap(\.layoutViews))
+        views.append(contentsOf: layouts.layoutViews)
         return views
     }
 }
-
 
 extension LayoutFlattening {
     var viewReferences: Set<WeakReference<UIView>> {

--- a/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
@@ -15,6 +15,11 @@ protocol LayoutFlattening {
     
 }
 
+extension UIView: LayoutFlattening {    
+    var layoutViews: [UIView] { [self] }
+    var layoutConstraints: [NSLayoutConstraint] { [] }
+}
+
 extension LayoutFlattening where Self: ContainableLayout {
     var layoutViews: [UIView] {
         (layouts as? [LayoutFlattening] ?? []).flatMap(\.layoutViews)

--- a/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/LayoutFlattening.swift
@@ -1,0 +1,16 @@
+//
+//  InternalLayout.swift
+//  
+//
+//  Created by oozoofrog on 2022/02/11.
+//
+
+import Foundation
+import UIKit
+
+protocol LayoutFlattening {
+    
+    var layoutViews: [UIView] { get }
+    var layoutConstraints: [NSLayoutConstraint] { get }
+    
+}

--- a/Sources/SwiftLayout/Layout/Protocol/ViewContainableLayout.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/ViewContainableLayout.swift
@@ -9,22 +9,14 @@ import Foundation
 import UIKit
 
 public protocol ViewContainableLayout: ContainableLayout {
-    var view: UIView? { get }
+    var view: UIView { get }
 }
 
-public extension ViewContainableLayout {
-    
-    func detachFromSuperview(_ superview: UIView?) {
-        guard let view = self.view else { return }
-        if let superview = superview, view.superview == superview {
-            view.removeFromSuperview()
-        }
+extension ViewContainableLayout {
+    public func detachFromSuperview() {
+        view.removeFromSuperview()
         for layout in layouts {
-            layout.detachFromSuperview(view)
+            layout.detachFromSuperview()
         }
-    }
-    
-    var hashable: AnyHashable {
-        AnyHashable(layouts.map(\.hashable) + [self.view.hashable])
     }
 }

--- a/Sources/SwiftLayout/Layout/Protocol/ViewContainableLayout.swift
+++ b/Sources/SwiftLayout/Layout/Protocol/ViewContainableLayout.swift
@@ -11,12 +11,3 @@ import UIKit
 public protocol ViewContainableLayout: ContainableLayout {
     var view: UIView { get }
 }
-
-extension ViewContainableLayout {
-    public func detachFromSuperview() {
-        view.removeFromSuperview()
-        for layout in layouts {
-            layout.detachFromSuperview()
-        }
-    }
-}

--- a/Sources/SwiftLayout/Util/WeakReference.swift
+++ b/Sources/SwiftLayout/Util/WeakReference.swift
@@ -1,0 +1,42 @@
+//
+//  WeakReference.swift
+//  
+//
+//  Created by oozoofrog on 2022/02/12.
+//
+
+import Foundation
+import UIKit
+
+final class WeakReference<O> where O: AnyObject {
+    internal init(o: O? = nil) {
+        self.o = o
+    }
+    
+    weak var o: O?
+}
+
+extension WeakReference: Equatable where O: Equatable {
+    static func == (lhs: WeakReference<O>, rhs: WeakReference<O>) -> Bool {
+        lhs.o == rhs.o
+    }
+}
+
+extension WeakReference: Hashable where O: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(o)
+    }
+}
+
+extension WeakReference where O == NSLayoutConstraint {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(o?.firstItem as? NSObject)
+        hasher.combine(o?.firstAttribute)
+        hasher.combine(o?.secondItem as? NSObject)
+        hasher.combine(o?.secondAttribute)
+        hasher.combine(o?.relation)
+        hasher.combine(o?.constant)
+        hasher.combine(o?.multiplier)
+        hasher.combine(o?.priority)
+    }
+}

--- a/Sources/SwiftLayout/Util/WeakReference.swift
+++ b/Sources/SwiftLayout/Util/WeakReference.swift
@@ -8,35 +8,41 @@
 import Foundation
 import UIKit
 
-final class WeakReference<O> where O: AnyObject {
+protocol CustomHashable: AnyObject {
+    func customHash(_ hasher: inout Hasher)
+}
+
+final class WeakReference<O>: Hashable where O: CustomHashable {
+    static func == (lhs: WeakReference<O>, rhs: WeakReference<O>) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+    
     internal init(o: O? = nil) {
         self.o = o
     }
     
     weak var o: O?
-}
-
-extension WeakReference: Equatable where O: Equatable {
-    static func == (lhs: WeakReference<O>, rhs: WeakReference<O>) -> Bool {
-        lhs.o == rhs.o
+    
+    func hash(into hasher: inout Hasher) {
+        o?.customHash(&hasher)
     }
 }
 
-extension WeakReference: Hashable where O: Hashable {
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(o)
+extension UIView: CustomHashable {
+    func customHash(_ hasher: inout Hasher) {
+        self.hash(into: &hasher)
     }
 }
 
-extension WeakReference where O == NSLayoutConstraint {
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(o?.firstItem as? NSObject)
-        hasher.combine(o?.firstAttribute)
-        hasher.combine(o?.secondItem as? NSObject)
-        hasher.combine(o?.secondAttribute)
-        hasher.combine(o?.relation)
-        hasher.combine(o?.constant)
-        hasher.combine(o?.multiplier)
-        hasher.combine(o?.priority)
+extension NSLayoutConstraint: CustomHashable {
+    func customHash(_ hasher: inout Hasher) {
+        hasher.combine(firstItem as? NSObject)
+        hasher.combine(firstAttribute)
+        hasher.combine(secondItem as? NSObject)
+        hasher.combine(secondAttribute)
+        hasher.combine(relation)
+        hasher.combine(constant)
+        hasher.combine(multiplier)
+        hasher.combine(priority)
     }
 }

--- a/Tests/SwiftLayoutTests/DSLTests.swift
+++ b/Tests/SwiftLayoutTests/DSLTests.swift
@@ -137,55 +137,6 @@ final class DSLTests: XCTestCase {
         XCTAssertEqual(root.findConstraints(items: (red, root), attributes: (.trailing, .trailing)).count, 1)
     }
     
-    func testCompareToLayoutWithAnchors() {
-        let withRed = root {
-            red
-        }
-        let withBlue = root {
-            blue
-        }
-        
-        XCTAssertNotEqual(withRed.hashable, withBlue.hashable)
-        
-        let red1 = root {
-            red
-        }
-        let red2 = root {
-            red
-        }
-        
-        XCTAssertEqual(red1.hashable, red2.hashable)
-        
-        let a1 = root {
-            red.anchors {
-                Anchors.cap
-            }
-        }
-        
-        let a2 = root {
-            red.anchors {
-                Anchors.cap
-            }
-        }
-        
-        XCTAssertEqual(a1.hashable, a2.hashable)
-        
-        let a3 = root {
-            red.anchors {
-                Anchors.cap
-            }
-        }
-        
-        let a4 = root {
-            red.anchors {
-                Anchors.shoe
-            }
-        }
-        
-        XCTAssertNotEqual(Anchors.cap.hashable, Anchors.shoe.hashable)
-        XCTAssertNotEqual(a3.hashable, a4.hashable)
-    }
-    
     func testConstraintDSL() {
         view = LayoutHostingView(root {
             red.anchors {

--- a/Tests/SwiftLayoutTests/DSLTests.swift
+++ b/Tests/SwiftLayoutTests/DSLTests.swift
@@ -203,28 +203,10 @@ final class DSLTests: XCTestCase {
     }
     
     func testViewLayout() {
-        
-        root.addSubview(red)
-        red.translatesAutoresizingMaskIntoConstraints = false
-        
-        NSLayoutConstraint.activate([
-            red.topAnchor.constraint(equalTo: root.topAnchor, constant: 10),
-            red.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 10),
-            red.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -10),
-            red.bottomAnchor.constraint(equalTo: root.bottomAnchor, constant: -10)
-        ])
-        
-        root.frame = .init(x: 0, y: 0, width: 30, height: 30)
-        root.setNeedsLayout()
-        root.layoutIfNeeded()
-        XCTAssertEqual(red.frame, .init(x: 10, y: 10, width: 10, height: 10))
-        
-        red.removeFromSuperview()
-        
         view = LayoutHostingView(root {
             red.anchors {
                 Anchors(.top, .leading).setConstant(10)
-                Anchors(.trailing, .bottom).setConstant(-10)
+                Anchors(.trailing, .bottom).setConstant(10)
             }
         })
         

--- a/Tests/SwiftLayoutTests/DSLTests.swift
+++ b/Tests/SwiftLayoutTests/DSLTests.swift
@@ -31,6 +31,18 @@ final class DSLTests: XCTestCase {
     override func tearDownWithError() throws {
     }
     
+    func testAutoresizingFlagOfRootView() {
+        root.translatesAutoresizingMaskIntoConstraints = true
+        
+        view = LayoutHostingView(root {
+            red.anchors {
+                Anchors.boundary
+            }
+        })
+        
+        XCTAssertTrue(root.translatesAutoresizingMaskIntoConstraints)
+    }
+    
     func testAnchors() {
      
         view = LayoutHostingView(root {
@@ -203,9 +215,7 @@ final class DSLTests: XCTestCase {
     }
     
     func testViewLayout() {
-        view = LayoutHostingView(root.anchors({
-            Anchors(.width, .height).equalTo(constant: 30)
-        }).subviews {
+        view = LayoutHostingView(root {
             red.anchors {
                 Anchors.boundary
             }

--- a/Tests/SwiftLayoutTests/DSLTests.swift
+++ b/Tests/SwiftLayoutTests/DSLTests.swift
@@ -203,18 +203,20 @@ final class DSLTests: XCTestCase {
     }
     
     func testViewLayout() {
-        view = LayoutHostingView(root {
+        view = LayoutHostingView(root.anchors({
+            Anchors(.width, .height).equalTo(constant: 30)
+        }).subviews {
             red.anchors {
-                Anchors(.top, .leading).setConstant(10)
-                Anchors(.trailing, .bottom).setConstant(10)
+                Anchors.boundary
             }
         })
         
-        root.frame = .init(x: 0, y: 0, width: 30, height: 30)
+        root.frame = .init(origin: .zero, size: .init(width: 30, height: 30))
         root.setNeedsLayout()
         root.layoutIfNeeded()
-        
-        XCTAssertEqual(red.frame, .init(x: 10, y: 10, width: 10, height: 10))
+
+        XCTAssertEqual(root.frame, .init(x: 0, y: 0, width: 30, height: 30))
+        XCTAssertEqual(red.frame, .init(x: 0, y: 0, width: 30, height: 30))
     }
     
     func testInitViewInLayout() {

--- a/Tests/SwiftLayoutTests/ImplementationTest.swift
+++ b/Tests/SwiftLayoutTests/ImplementationTest.swift
@@ -116,29 +116,53 @@ final class ImplementationTest: XCTestCase {
         }
     }
     
-    func testUpdateLayout() {
+    class LayoutView: UIView, LayoutBuilding {
+        
+        var flag = true
+        
         let root = MockView()
         let child = UIView()
         let friend = UIView()
         
-        var flag = true
-        let view = LayoutHostingView(root {
-            if flag {
-                child.anchors {
-                    Anchors.boundary
-                }
-            } else {
-                friend.anchors {
-                    Anchors.boundary
+        var deactivatable: Deactivable?
+        
+        var layout: some Layout {
+            root {
+                if flag {
+                    child.anchors {
+                        Anchors.boundary
+                    }
+                } else {
+                    friend.anchors {
+                        Anchors.boundary
+                    }
                 }
             }
-        })
+        }
+    }
+    
+    func testUpdateLayout() {
+
+        let view = LayoutView()
+        let root = view.root
+        view.updateLayout()
         
         XCTAssertEqual(root.addSubviewCount, 1)
         
         view.updateLayout()
         
         XCTAssertEqual(root.addSubviewCount, 1)
+        XCTAssertEqual(root.constraints.count, 4)
+        XCTAssertEqual(view.child.superview, root)
+        XCTAssertNil(view.friend.superview)
+        
+        view.flag.toggle()
+        view.updateLayout()
+        
+        XCTAssertEqual(root.addSubviewCount, 2)
+        XCTAssertEqual(root.constraints.count, 4)
+        XCTAssertEqual(view.friend.superview, root)
+        XCTAssertNil(view.child.superview)
     }
 }
     

--- a/Tests/SwiftLayoutTests/ImplementationTest.swift
+++ b/Tests/SwiftLayoutTests/ImplementationTest.swift
@@ -108,8 +108,37 @@ final class ImplementationTest: XCTestCase {
         
     }
     
+    class MockView: UIView {
+        var addSubviewCount = 0
+        override func addSubview(_ view: UIView) {
+            addSubviewCount += 1
+            super.addSubview(view)
+        }
+    }
+    
     func testUpdateLayout() {
+        let root = MockView()
+        let child = UIView()
+        let friend = UIView()
         
+        var flag = true
+        let view = LayoutHostingView(root {
+            if flag {
+                child.anchors {
+                    Anchors.boundary
+                }
+            } else {
+                friend.anchors {
+                    Anchors.boundary
+                }
+            }
+        })
+        
+        XCTAssertEqual(root.addSubviewCount, 1)
+        
+        view.updateLayout()
+        
+        XCTAssertEqual(root.addSubviewCount, 1)
     }
 }
     

--- a/Tests/SwiftLayoutTests/ImplementationTest.swift
+++ b/Tests/SwiftLayoutTests/ImplementationTest.swift
@@ -45,5 +45,24 @@ final class ImplementationTest: XCTestCase {
         XCTAssertNil(weakView)
         XCTAssertEqual(deinitCount, 2)
     }
+    
+    func testLayoutFlattening() {
+        let root = UIView()
+        let child = UIView()
+        let friend = UIView()
+        let layout: some Layout = root {
+            child.anchors {
+                Anchors.boundary
+            }.subviews {
+                friend.anchors {
+                    Anchors.boundary
+                }
+            }
+        }
+        
+        let flattening = layout as? LayoutFlattening
+        
+        XCTAssertNotNil(flattening)
+    }
 }
     

--- a/Tests/SwiftLayoutTests/ImplementationTest.swift
+++ b/Tests/SwiftLayoutTests/ImplementationTest.swift
@@ -63,6 +63,7 @@ final class ImplementationTest: XCTestCase {
         let flattening = layout as? LayoutFlattening
         
         XCTAssertNotNil(flattening)
+        XCTAssertEqual(flattening?.layoutViews, [root, child, friend])
     }
     
     func testLayoutCompare() {
@@ -121,8 +122,8 @@ final class ImplementationTest: XCTestCase {
         var flag = true
         
         let root = MockView()
-        let child = UIView()
-        let friend = UIView()
+        let child = UIView().viewTag.child
+        let friend = UIView().viewTag.friend
         
         var deactivatable: Deactivable?
         
@@ -152,7 +153,7 @@ final class ImplementationTest: XCTestCase {
         view.updateLayout()
         
         XCTAssertEqual(root.addSubviewCount, 1)
-        XCTAssertEqual(root.constraints.count, 4)
+        XCTAssertEqual(root.findConstraints(items: (view.child, root)).count, 4)
         XCTAssertEqual(view.child.superview, root)
         XCTAssertNil(view.friend.superview)
         
@@ -160,7 +161,7 @@ final class ImplementationTest: XCTestCase {
         view.updateLayout()
         
         XCTAssertEqual(root.addSubviewCount, 2)
-        XCTAssertEqual(root.constraints.count, 4)
+        XCTAssertEqual(root.findConstraints(items: (view.friend, root)).count, 4)
         XCTAssertEqual(view.friend.superview, root)
         XCTAssertNil(view.child.superview)
     }

--- a/Tests/SwiftLayoutTests/ImplementationTest.swift
+++ b/Tests/SwiftLayoutTests/ImplementationTest.swift
@@ -64,5 +64,52 @@ final class ImplementationTest: XCTestCase {
         
         XCTAssertNotNil(flattening)
     }
+    
+    func testLayoutCompare() {
+        let root = UIView()
+        let child = UIView()
+        let friend = UIView()
+        
+        let f1 = root {
+            child
+        }.flattening()
+        
+        let f2 = root {
+           child
+        }.flattening()
+        
+        let f3 = root {
+            child.anchors { Anchors.boundary }
+        }.flattening()
+        
+        let f4 = root {
+            child.anchors { Anchors.boundary }
+        }.flattening()
+        
+        let f5 = root {
+            child.anchors { Anchors.cap }
+        }.flattening()
+        
+        let f6 = root {
+            friend.anchors { Anchors.boundary }
+        }.flattening()
+        
+        XCTAssertEqual(f1?.viewReferences, f2?.viewReferences)
+        XCTAssertEqual(f1?.constraintReferences, f2?.constraintReferences)
+        
+        XCTAssertEqual(f3?.viewReferences, f4?.viewReferences)
+        XCTAssertEqual(f3?.constraintReferences, f4?.constraintReferences)
+        
+        XCTAssertEqual(f4?.viewReferences, f5?.viewReferences)
+        XCTAssertNotEqual(f4?.constraintReferences, f5?.constraintReferences)
+        
+        XCTAssertNotEqual(f5?.viewReferences, f6?.viewReferences)
+        XCTAssertNotEqual(f5?.constraintReferences, f6?.constraintReferences)
+        
+    }
+    
+    func testUpdateLayout() {
+        
+    }
 }
     


### PR DESCRIPTION
- move deactivation codes to in **Deactivation**
- layout hierarchy will be flattening after activation
- remove duplication of layout updates