### PR TITLE
suppress fatal error from LayoutImp

### DIFF
--- a/Sources/SwiftLayout/Layout/Implementation/LayoutImp.swift
+++ b/Sources/SwiftLayout/Layout/Implementation/LayoutImp.swift
@@ -36,7 +36,8 @@ struct LayoutImp: Layout {
             self.sublayouts = sublayoutImp ?? layoutImp.sublayouts
             self.anchors = anchors ?? layoutImp.anchors
         } else {
-            fatalError("The layout protocol does not allow external adoption")
+            assertionFailure("The layout protocol does not allow external adoption")
+            return nil
         }
     }
     


### PR DESCRIPTION
come to think of it, it would be a little dangerous for the library to cause a fatal error. it seems that developers can't test some cases, as a result may cause crash at time on using by users. how about we change this part to assertion only be checked when debugging?

@gmlwhdtjd 