### PR TITLE
anchors from layoutanchor

### DIFF
--- a/Sources/SwiftLayout/Components/Anchors/Anchors.swift
+++ b/Sources/SwiftLayout/Components/Anchors/Anchors.swift
@@ -254,7 +254,7 @@ extension Anchors {
 }
 
 extension Anchors {
-    private struct ConstraintTarget {
+    struct ConstraintTarget {
         init<I>(item: I?, attribute: NSLayoutConstraint.Attribute?, constant: CGFloat) where I: ConstraintableItem {
             self.item = ItemFromView(item).item
             self.attribute = attribute

--- a/Sources/SwiftLayout/Components/Anchors/Anchors.swift
+++ b/Sources/SwiftLayout/Components/Anchors/Anchors.swift
@@ -330,3 +330,26 @@ extension Anchors {
         }
     }
 }
+
+public extension Anchors {
+    
+    func equalTo<LA: LayoutAnchor&NSObject>(_ layoutAnchor: LA, constant: CGFloat = .zero) -> Self? {
+        guard let target = layoutAnchor.constraintTargetWithConstant(constant) else { return nil }
+        return to(.equal, to: target)
+    }
+    
+    func greaterThanOrEqualTo<LA: LayoutAnchor&NSObject>(_ layoutAnchor: LA, constant: CGFloat = .zero) -> Self? {
+        guard let target = layoutAnchor.constraintTargetWithConstant(constant) else { return nil }
+        return to(.greaterThanOrEqual, to: target)
+    }
+    
+    func lessThanOrEqualTo<LA: LayoutAnchor&NSObject>(_ layoutAnchor: LA, constant: CGFloat = .zero) -> Self? {
+        guard let target = layoutAnchor.constraintTargetWithConstant(constant) else { return nil }
+        return to(.lessThanOrEqual, to: target)
+    }
+    
+}
+
+func ==<LA: LayoutAnchor&NSObject, RA: LayoutAnchor&NSObject>(_ lhs: LA, _ rhs: RA) -> Bool {
+    lhs.isEqual(rhs)
+}

--- a/Sources/SwiftLayout/Components/Anchors/LayoutAnchor.swift
+++ b/Sources/SwiftLayout/Components/Anchors/LayoutAnchor.swift
@@ -1,0 +1,14 @@
+//
+//  LayoutAnchor.swift
+//  
+//
+//  Created by oozoofrog on 2022/02/22.
+//
+
+import Foundation
+import UIKit
+
+public protocol LayoutAnchor {}
+extension NSLayoutDimension: LayoutAnchor {}
+extension NSLayoutXAxisAnchor: LayoutAnchor {}
+extension NSLayoutYAxisAnchor: LayoutAnchor {}

--- a/Sources/SwiftLayout/Extension/UIView+LayoutAnchor.swift
+++ b/Sources/SwiftLayout/Extension/UIView+LayoutAnchor.swift
@@ -1,0 +1,105 @@
+//
+//  UIView+LayoutAnchor.swift
+//  
+//
+//  Created by oozoofrog on 2022/02/22.
+//
+
+import Foundation
+import UIKit
+
+extension LayoutAnchor where Self: NSObject {
+    var item: NSObject? {
+        let value = value(forKey: "item")
+        if value is NSObject {
+            return value as? NSObject
+        } else {
+            return nil
+        }
+    }
+    var view: UIView? {
+        if item is UIView {
+            return item as? UIView
+        } else {
+            return nil
+        }
+    }
+    
+    var layoutGuide: UILayoutGuide? {
+        if item is UILayoutGuide {
+            return item as? UILayoutGuide
+        } else {
+            return nil
+        }
+    }
+    
+    func constraintTargetWithConstant(_ constant: CGFloat) -> Anchors.ConstraintTarget? {
+        if let view = view {
+            return Anchors.ConstraintTarget(item: view, attribute: view.attributeFromAnchor(self), constant: constant)
+        } else if let layoutGuide = layoutGuide {
+            return Anchors.ConstraintTarget(item: layoutGuide, attribute: layoutGuide.attributeFromAnchor(self), constant: constant)
+        } else {
+            return nil
+        }
+    }
+}
+
+extension UIView {
+    func attributeFromAnchor<LA: LayoutAnchor&NSObject>(_ anchor: LA) -> NSLayoutConstraint.Attribute {
+        if self.topAnchor == anchor {
+            return .top
+        } else if self.bottomAnchor == anchor {
+            return .bottom
+        } else if self.leadingAnchor == anchor {
+            return .leading
+        } else if self.trailingAnchor == anchor {
+            return .trailing
+        } else if self.leftAnchor == anchor {
+            return .left
+        } else if self.rightAnchor == anchor {
+            return .right
+        } else if self.centerXAnchor == anchor {
+            return .centerX
+        } else if self.centerYAnchor == anchor {
+            return .centerY
+        } else if self.widthAnchor == anchor {
+            return .width
+        } else if self.heightAnchor == anchor {
+            return .height
+        } else if self.firstBaselineAnchor == anchor {
+            return .firstBaseline
+        } else if self.lastBaselineAnchor == anchor {
+            return .lastBaseline
+        } else {
+            return .notAnAttribute
+        }
+    }
+}
+
+extension UILayoutGuide {
+    func attributeFromAnchor<LA: LayoutAnchor&NSObject>(_ anchor: LA) -> NSLayoutConstraint.Attribute {
+        if self.topAnchor == anchor {
+            return .top
+        } else if self.bottomAnchor == anchor {
+            return .bottom
+        } else if self.leadingAnchor == anchor {
+            return .leading
+        } else if self.trailingAnchor == anchor {
+            return .trailing
+        } else if self.leftAnchor == anchor {
+            return .left
+        } else if self.rightAnchor == anchor {
+            return .right
+        } else if self.centerXAnchor == anchor {
+            return .centerX
+        } else if self.centerYAnchor == anchor {
+            return .centerY
+        } else if self.widthAnchor == anchor {
+            return .width
+        } else if self.heightAnchor == anchor {
+            return .height
+        } else {
+            return .notAnAttribute
+        }
+    }
+}

--- a/Tests/SwiftLayoutTests/AnchorsDSLTest.swift
+++ b/Tests/SwiftLayoutTests/AnchorsDSLTest.swift
@@ -359,3 +359,88 @@ extension AnchorsDSLTest {
         XCTAssertEqual(SwiftLayoutPrinter(root).print(), expect)
     }
 }
+
+// MARK: - Anchors from UILayoutAnchor
+extension AnchorsDSLTest {
+    
+    func testAnchorsEqualToUILayoutAnchor() {
+        deactivable = root {
+            red.anchors {
+                Anchors(.top).equalTo(root.topAnchor)
+                Anchors(.leading).equalTo(root.leadingAnchor)
+                Anchors(.trailing).equalTo(root.trailingAnchor, constant: -14.0)
+                Anchors(.bottom).equalTo(root.bottomAnchor)
+                Anchors(.width).equalTo(root.widthAnchor)
+                Anchors(.height).equalTo(root.heightAnchor)
+                Anchors(.centerX).equalTo(root.centerXAnchor)
+                Anchors(.centerY).equalTo(root.centerYAnchor)
+            }
+        }.active()
+        
+        let expect = """
+        root {
+            red.anchors {
+                Anchors(.top, .leading, .bottom, .width, .height, .centerX, .centerY)
+                Anchors(.trailing).equalTo(constant: -14.0)
+            }
+        }
+        """.tabbed
+        
+        XCTAssertEqual(SwiftLayoutPrinter(root).print(), expect)
+    }
+    
+    func testAnchorsGreaterThanOrEqualToUILayoutAnchor() {
+        
+        deactivable = root {
+            red.anchors {
+                Anchors(.top).greaterThanOrEqualTo(root.topAnchor)
+                Anchors(.leading).greaterThanOrEqualTo(root.leadingAnchor)
+                Anchors(.trailing).greaterThanOrEqualTo(root.trailingAnchor)
+                Anchors(.bottom).greaterThanOrEqualTo(root.bottomAnchor, constant: 13)
+                Anchors(.width).greaterThanOrEqualTo(root.widthAnchor)
+                Anchors(.height).greaterThanOrEqualTo(root.heightAnchor)
+                Anchors(.centerX).greaterThanOrEqualTo(root.centerXAnchor)
+                Anchors(.centerY).greaterThanOrEqualTo(root.centerYAnchor)
+            }
+        }.active()
+        
+        let expect = """
+        root {
+            red.anchors {
+                Anchors(.top, .leading, .trailing, .width, .height, .centerX, .centerY).greaterThanOrEqualTo()
+                Anchors(.bottom).greaterThanOrEqualTo(constant: 13.0)
+            }
+        }
+        """.tabbed
+        
+        XCTAssertEqual(SwiftLayoutPrinter(root).print(), expect)
+    }
+    
+    func testAnchorsLessThanOrEqualToUILayoutAnchor() {
+        
+        deactivable = root {
+            red.anchors {
+                Anchors(.top).lessThanOrEqualTo(root.topAnchor)
+                Anchors(.leading).lessThanOrEqualTo(root.leadingAnchor)
+                Anchors(.trailing).lessThanOrEqualTo(root.trailingAnchor)
+                Anchors(.bottom).lessThanOrEqualTo(root.bottomAnchor)
+                Anchors(.width).lessThanOrEqualTo(root.widthAnchor)
+                Anchors(.height).lessThanOrEqualTo(root.heightAnchor, constant: 12)
+                Anchors(.centerX).lessThanOrEqualTo(root.centerXAnchor)
+                Anchors(.centerY).lessThanOrEqualTo(root.centerYAnchor)
+            }
+        }.active()
+        
+        let expect = """
+        root {
+            red.anchors {
+                Anchors(.top, .leading, .trailing, .bottom, .width, .centerX, .centerY).lessThanOrEqualTo()
+                Anchors(.height).lessThanOrEqualTo(constant: 12.0)
+            }
+        }
+        """.tabbed
+        
+        XCTAssertEqual(SwiftLayoutPrinter(root).print(), expect)
+    }
+    
+}


### PR DESCRIPTION
- create Anchors from NSLayoutAnchor
- add test for Anchors from UILayoutAnchor

directly allow NSLayoutConstraint was not so looks good. but how about this?

```swift
root {
   red.anchors {
       Anchors(.trailing).equalTo(root.trailingAnchor, constant: -14.0)
   }
}
```