### PR TITLE
identifying trailing enabled after config

### DIFF
--- a/Sources/SwiftLayout/Components/Layout/Layout.swift
+++ b/Sources/SwiftLayout/Components/Layout/Layout.swift
@@ -39,6 +39,13 @@ extension Layout {
     public func subviews<L: Layout>(@LayoutBuilder _ build: () -> L) -> some Layout {
         sublayout(build)
     }
+    
+    public func identifying(_ accessibilityIdentifier: String) -> some Layout {
+        traverse(nil, continueAfterViewLayout: false) { superview, subview, identifier, animationDisabled in
+            subview.accessibilityIdentifier = accessibilityIdentifier
+        }
+        return self
+    }
 }
 
 extension Layout {

--- a/Sources/SwiftLayout/Components/Layout/Layouts/ViewLayout.swift
+++ b/Sources/SwiftLayout/Components/Layout/Layouts/ViewLayout.swift
@@ -40,7 +40,6 @@ public final class ViewLayout<V: UIView, SubLayout: Layout>: Layout {
     public func subviews<L: Layout>(@LayoutBuilder _ build: () -> L) -> some Layout {
         sublayout(build)
     }
-   
 }
 
 public extension ViewLayout {

--- a/Sources/SwiftLayout/Extension/UIVIew+Layout.swift
+++ b/Sources/SwiftLayout/Extension/UIVIew+Layout.swift
@@ -25,10 +25,4 @@ public extension Layout where Self: UIView {
         config(self)
         return ViewLayout(self, sublayout: EmptyLayout())
     }
-    
-    func identifying(_ identifier: String) -> some Layout {
-        let layout = ViewLayout(self, sublayout: EmptyLayout())
-        layout.identifier = identifier
-        return layout
-    }
 }

--- a/Tests/SwiftLayoutTests/LayoutDSLTest.swift
+++ b/Tests/SwiftLayoutTests/LayoutDSLTest.swift
@@ -331,7 +331,7 @@ extension LayoutDSLTest {
                 Anchors(.leading, .trailing, .bottom)
             }
         }
-        """
+        """.tabbed
         
         XCTAssertEqual(SwiftLayoutPrinter(root).print(), expect)
     }

--- a/Tests/SwiftLayoutTests/LayoutDSLTest.swift
+++ b/Tests/SwiftLayoutTests/LayoutDSLTest.swift
@@ -301,4 +301,38 @@ extension LayoutDSLTest {
         
         XCTAssertEqual(root.subviews.count, 2)
     }
+    
+    func testFeatureCompose() {
+        root {
+            UILabel().config { label in
+                label.text = "HELLO"
+            }.identifying("label").anchors {
+                Anchors.cap()
+            }.sublayout {
+                UIView().identifying("UIView").anchors {
+                    Anchors.allSides()
+                }
+            }
+            UIButton().identifying("button").anchors {
+                Anchors.shoe()
+            }
+        }.active().store(&deactivable)
+        
+        let expect = """
+        root {
+            label.anchors {
+                Anchors(.leading, .trailing, .top)
+            }.sublayout {
+                UIView.anchors {
+                    Anchors(.leading, .trailing, .top, .bottom)
+                }
+            }
+            button.anchors {
+                Anchors(.leading, .trailing, .bottom)
+            }
+        }
+        """
+        
+        XCTAssertEqual(SwiftLayoutPrinter(root).print(), expect)
+    }
 }


### PR DESCRIPTION
```swift
root {
    UILabel().config { label in
        label.text = "HELLO"
    }.identifying("label").anchors {
        Anchors.cap()
    }.sublayout {
        UIView().identifying("UIView").anchors {
            Anchors.allSides()
        }
    }
    UIButton().identifying("button").anchors {
        Anchors.shoe()
    }
}
```