### PR TITLE
some fixes

### DIFF
--- a/Sources/SwiftLayout/Components/Layout/ViewInformation.swift
+++ b/Sources/SwiftLayout/Components/Layout/ViewInformation.swift
@@ -44,6 +44,7 @@ public final class ViewInformation: Hashable {
     }
     
     func removeFromSuperview() {
+        guard superview != nil else { return }
         view?.removeFromSuperview()
     }
     

--- a/Sources/SwiftLayout/Printing/SwiftLayoutPrinter.swift
+++ b/Sources/SwiftLayout/Printing/SwiftLayoutPrinter.swift
@@ -251,6 +251,7 @@ private struct ConstraintToken: CustomStringConvertible, Hashable {
         return self.firstTag == token.firstTag
         && self.secondTag == token.secondTag
         && self.constant == token.constant
+        && self.multiplier == token.multiplier
         && self.relation == token.relation
     }
 }

--- a/Sources/SwiftLayout/Printing/SwiftLayoutPrinter.swift
+++ b/Sources/SwiftLayout/Printing/SwiftLayoutPrinter.swift
@@ -132,6 +132,7 @@ private struct ConstraintToken: CustomStringConvertible, Hashable {
         secondAttribute = constraint.secondAttribute.description
         relation = constraint.relation.description
         constant = constraint.constant.description
+        multiplier = constraint.multiplier.description
     }
     
     let superTag: String
@@ -142,6 +143,7 @@ private struct ConstraintToken: CustomStringConvertible, Hashable {
     let secondAttribute: String
     let relation: String
     let constant: String
+    let multiplier: String
     
     var description: String {
         var descriptions: [String] = ["Anchors(\(firstAttributes.map({ "." + $0 }).joined(separator: ", ")))"]
@@ -157,6 +159,9 @@ private struct ConstraintToken: CustomStringConvertible, Hashable {
         }
         if !arguments.isEmpty || relation != "equal" {
             descriptions.append("\(relation)To(\(arguments.joined(separator: ", ")))")
+        }
+        if multiplier != "1.0" {
+            descriptions.append("setMultiplier(\(multiplier))")
         }
         return descriptions.joined(separator: ".")
     }

--- a/Sources/SwiftLayout/Util/IdentifierUpdater.swift
+++ b/Sources/SwiftLayout/Util/IdentifierUpdater.swift
@@ -53,7 +53,9 @@ public struct IdentifierUpdater {
             guard let mirror = mirror else {
                 return []
             }
-            return mirror.children.compactMap(Identified.init) + dig(mirror.superclassMirror)
+            return mirror.children.compactMap(Identified.init).flatMap({ identified in
+                [identified] + dig(Mirror(reflecting: identified.view))
+            }) + dig(mirror.superclassMirror)
         }
     }
 }

--- a/Tests/SwiftLayoutTests/LayoutDSLTest.swift
+++ b/Tests/SwiftLayoutTests/LayoutDSLTest.swift
@@ -393,10 +393,26 @@ extension LayoutDSLTest {
         
         let first = First()
         
+        let printer = SwiftLayoutPrinter(first,
+                                         tags: [first: "first", first.child.button: "child.button"],
+                                         options: .automaticIdentifierAssignment)
         let expect = """
-        
+        first {
+            label.anchors {
+                Anchors(.leading, .trailing, .top)
+                Anchors(.height).equalTo(first).setMultiplier(0.7)
+            }
+            child.anchors {
+                Anchors(.top).equalTo(label, attribute: .bottom)
+                Anchors(.leading, .trailing, .bottom)
+            }.sublayout {
+                child.button.anchors {
+                    Anchors(.centerX, .centerY)
+                }
+            }
+        }
         """.tabbed
         
-        XCTAssertEqual(SwiftLayoutPrinter(first, tags: [first: "first", first.child.button: "child.button"], options: .automaticIdentifierAssignment).print(), expect)
+        XCTAssertEqual(printer.print(), expect)
     }
 }

--- a/Tests/SwiftLayoutTests/LayoutDSLTest.swift
+++ b/Tests/SwiftLayoutTests/LayoutDSLTest.swift
@@ -336,62 +336,76 @@ extension LayoutDSLTest {
         XCTAssertEqual(SwiftLayoutPrinter(root).print(), expect)
     }
     
+}
+
+// MARK: - LayoutBuilding in LayoutBuilding
+extension LayoutDSLTest {
+    
+    class Child: UIView, LayoutBuilding {
+        lazy var button = UIButton()
+        
+        var deactivable: Deactivable?
+        var layout: some Layout {
+            self {
+                button.anchors {
+                    Anchors(.centerX, .centerY)
+                }
+            }
+        }
+        
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            updateLayout()
+        }
+        
+        required init?(coder: NSCoder) {
+            super.init(coder: coder)
+            updateLayout()
+        }
+    }
+    
+    class First: UIView, LayoutBuilding {
+        
+        lazy var label = UILabel()
+        lazy var child = Child()
+        
+        var deactivable: Deactivable?
+        var layout: some Layout {
+            self {
+                label.anchors {
+                    Anchors.cap()
+                    Anchors(.height).setMultiplier(multiplier)
+                }
+                child.anchors {
+                    Anchors(.top).equalTo(label, attribute: .bottom)
+                    Anchors.shoe()
+                }
+            }
+        }
+        
+        var multiplier: CGFloat = 1.0
+        
+        convenience init(multiplier: CGFloat) {
+            self.init(frame: .zero)
+            self.multiplier = multiplier
+            updateLayout()
+        }
+        
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            updateLayout()
+        }
+        
+        required init?(coder: NSCoder) {
+            super.init(coder: coder)
+            updateLayout()
+        }
+    }
+    
+    
     func testLayoutBuildingInRelation() {
-        
-        class Child: UIView, LayoutBuilding {
-            lazy var button = UIButton()
-            
-            var deactivable: Deactivable?
-            var layout: some Layout {
-                self {
-                    button.anchors {
-                        Anchors(.centerX, .centerY)
-                    }
-                }
-            }
-            
-            override init(frame: CGRect) {
-                super.init(frame: frame)
-                updateLayout()
-            }
-            
-            required init?(coder: NSCoder) {
-                super.init(coder: coder)
-                updateLayout()
-            }
-        }
-        
-        class First: UIView, LayoutBuilding {
-            
-            lazy var label = UILabel()
-            lazy var child = Child()
-            
-            var deactivable: Deactivable?
-            var layout: some Layout {
-                self {
-                    label.anchors {
-                        Anchors.cap()
-                        Anchors(.height).equalTo(self).setMultiplier(0.7)
-                    }
-                    child.anchors {
-                        Anchors(.top).equalTo(label, attribute: .bottom)
-                        Anchors.shoe()
-                    }
-                }
-            }
-            
-            override init(frame: CGRect) {
-                super.init(frame: frame)
-                updateLayout()
-            }
-            
-            required init?(coder: NSCoder) {
-                super.init(coder: coder)
-                updateLayout()
-            }
-        }
-        
-        let first = First()
+       
+        let first = First(multiplier: 0.75)
         
         let printer = SwiftLayoutPrinter(first,
                                          tags: [first: "first", first.child.button: "child.button"],
@@ -400,7 +414,7 @@ extension LayoutDSLTest {
         first {
             label.anchors {
                 Anchors(.leading, .trailing, .top)
-                Anchors(.height).equalTo(first).setMultiplier(0.7)
+                Anchors(.height).setMultiplier(0.75)
             }
             child.anchors {
                 Anchors(.top).equalTo(label, attribute: .bottom)

--- a/Tests/SwiftLayoutTests/LayoutDSLTest.swift
+++ b/Tests/SwiftLayoutTests/LayoutDSLTest.swift
@@ -408,7 +408,7 @@ extension LayoutDSLTest {
         let first = First(multiplier: 0.75)
         
         let printer = SwiftLayoutPrinter(first,
-                                         tags: [first: "first", first.child.button: "child.button"],
+                                         tags: [first: "first"],
                                          options: .automaticIdentifierAssignment)
         let expect = """
         first {
@@ -420,7 +420,7 @@ extension LayoutDSLTest {
                 Anchors(.top).equalTo(label, attribute: .bottom)
                 Anchors(.leading, .trailing, .bottom)
             }.sublayout {
-                child.button.anchors {
+                button.anchors {
                     Anchors(.centerX, .centerY)
                 }
             }

--- a/Tests/SwiftLayoutTests/LayoutDSLTest.swift
+++ b/Tests/SwiftLayoutTests/LayoutDSLTest.swift
@@ -3,7 +3,7 @@ import UIKit
 import SwiftLayout
 
 final class LayoutDSLTest: XCTestCase {
-        
+    
     var root: UIView = UIView().viewTag.root
     var child: UIView = UIView().viewTag.child
     var button: UIButton = UIButton().viewTag.button
@@ -164,7 +164,7 @@ extension LayoutDSLTest {
     
     func testLayoutIfWithTrueFlag() {
         let flag = true
-
+        
         root {
             red {
                 button
@@ -185,7 +185,7 @@ extension LayoutDSLTest {
     
     func testLayoutIfWithFalseFlag() {
         let flag = false
-
+        
         root {
             red {
                 button
@@ -207,7 +207,7 @@ extension LayoutDSLTest {
     
     func testLayoutEitherWithTrueFlag() {
         let flag = true
-
+        
         root {
             red {
                 button
@@ -231,7 +231,7 @@ extension LayoutDSLTest {
     
     func testLayoutEitherWithFalseFlag() {
         let flag = false
-
+        
         root {
             red {
                 button
@@ -257,7 +257,7 @@ extension LayoutDSLTest {
     func testLayoutWithOptionalViews() {
         let optionalView: UIView? = UIView().viewTag.optionalView
         let nilView: UIView? = nil
-
+        
         root {
             red {
                 button
@@ -342,13 +342,26 @@ extension LayoutDSLTest {
 extension LayoutDSLTest {
     
     class Child: UIView, LayoutBuilding {
+        
+        var showName: Bool = false {
+            didSet {
+                updateLayout()
+            }
+        }
         lazy var button = UIButton()
+        lazy var name = UILabel()
         
         var deactivable: Deactivable?
         var layout: some Layout {
             self {
-                button.anchors {
-                    Anchors(.centerX, .centerY)
+                if showName {
+                    name.anchors {
+                        Anchors(.centerX, .centerY)
+                    }
+                } else {
+                    button.anchors {
+                        Anchors(.centerX, .centerY)
+                    }
                 }
             }
         }
@@ -404,29 +417,55 @@ extension LayoutDSLTest {
     
     
     func testLayoutBuildingInRelation() {
-       
+        
         let first = First(multiplier: 0.75)
         
-        let printer = SwiftLayoutPrinter(first,
-                                         tags: [first: "first"],
-                                         options: .automaticIdentifierAssignment)
-        let expect = """
-        first {
-            label.anchors {
-                Anchors(.leading, .trailing, .top)
-                Anchors(.height).setMultiplier(0.75)
-            }
-            child.anchors {
-                Anchors(.top).equalTo(label, attribute: .bottom)
-                Anchors(.leading, .trailing, .bottom)
-            }.sublayout {
-                button.anchors {
-                    Anchors(.centerX, .centerY)
+        context("check multiplier setting") {
+            
+            let printer = SwiftLayoutPrinter(first,
+                                             tags: [first: "first"],
+                                             options: .automaticIdentifierAssignment)
+            let expect = """
+            first {
+                label.anchors {
+                    Anchors(.leading, .trailing, .top)
+                    Anchors(.height).setMultiplier(0.75)
+                }
+                child.anchors {
+                    Anchors(.top).equalTo(label, attribute: .bottom)
+                    Anchors(.leading, .trailing, .bottom)
+                }.sublayout {
+                    button.anchors {
+                        Anchors(.centerX, .centerY)
+                    }
                 }
             }
+            """.tabbed
+            
+            XCTAssertEqual(printer.print(), expect)
         }
-        """.tabbed
         
-        XCTAssertEqual(printer.print(), expect)
+        context("child shoe name label") {
+            first.child.showName.toggle()
+            let printer = SwiftLayoutPrinter(first, tags: [first: "first"], options: .automaticIdentifierAssignment)
+            let expect = """
+            first {
+                label.anchors {
+                    Anchors(.leading, .trailing, .top)
+                    Anchors(.height).setMultiplier(0.75)
+                }
+                child.anchors {
+                    Anchors(.top).equalTo(label, attribute: .bottom)
+                    Anchors(.leading, .trailing, .bottom)
+                }.sublayout {
+                    name.anchors {
+                        Anchors(.centerX, .centerY)
+                    }
+                }
+            }
+            """.tabbed
+            
+            XCTAssertEqual(printer.print(), expect)
+        }
     }
 }

--- a/Tests/SwiftLayoutTests/LayoutDSLTest.swift
+++ b/Tests/SwiftLayoutTests/LayoutDSLTest.swift
@@ -335,4 +335,68 @@ extension LayoutDSLTest {
         
         XCTAssertEqual(SwiftLayoutPrinter(root).print(), expect)
     }
+    
+    func testLayoutBuildingInRelation() {
+        
+        class Child: UIView, LayoutBuilding {
+            lazy var button = UIButton()
+            
+            var deactivable: Deactivable?
+            var layout: some Layout {
+                self {
+                    button.anchors {
+                        Anchors(.centerX, .centerY)
+                    }
+                }
+            }
+            
+            override init(frame: CGRect) {
+                super.init(frame: frame)
+                updateLayout()
+            }
+            
+            required init?(coder: NSCoder) {
+                super.init(coder: coder)
+                updateLayout()
+            }
+        }
+        
+        class First: UIView, LayoutBuilding {
+            
+            lazy var label = UILabel()
+            lazy var child = Child()
+            
+            var deactivable: Deactivable?
+            var layout: some Layout {
+                self {
+                    label.anchors {
+                        Anchors.cap()
+                        Anchors(.height).equalTo(self).setMultiplier(0.7)
+                    }
+                    child.anchors {
+                        Anchors(.top).equalTo(label, attribute: .bottom)
+                        Anchors.shoe()
+                    }
+                }
+            }
+            
+            override init(frame: CGRect) {
+                super.init(frame: frame)
+                updateLayout()
+            }
+            
+            required init?(coder: NSCoder) {
+                super.init(coder: coder)
+                updateLayout()
+            }
+        }
+        
+        let first = First()
+        
+        let expect = """
+        
+        """.tabbed
+        
+        XCTAssertEqual(SwiftLayoutPrinter(first, tags: [first: "first", first.child.button: "child.button"], options: .automaticIdentifierAssignment).print(), expect)
+    }
 }


### PR DESCRIPTION
- SwiftLayoutPrinter now print multiplier information
- improve IdentifierUpdater searching logic
- if there is no superview in view information, it ignore calling removefromsuperview of view
