### PR TITLE
fix infinite diggin in IdentifierUpdater

### DIFF
--- a/Tests/SwiftLayoutTests/PrintingTests.swift
+++ b/Tests/SwiftLayoutTests/PrintingTests.swift
@@ -434,7 +434,7 @@ extension PrintingTests {
     }
     
     class Gont: Earth, LayoutBuilding {
-        let duny = Duny()
+        lazy var duny = Duny(in: self)
         
         var deactivable: Deactivable?
         var layout: some Layout {
@@ -465,6 +465,14 @@ extension PrintingTests {
     }
     
     class Duny: Wizard, LayoutBuilding {
+        
+        init(in earth: Earth) {
+            super.init(frame: .zero)
+            self.earth = earth
+            updateLayout(.automaticIdentifierAssignment)
+        }
+        
+        weak var earth: Earth?
         let nickname = UILabel()
         
         var deactivable: Deactivable?


### PR DESCRIPTION
has [weak] reference of owner view like below cause infinite digging when using `IdentifierUpdater`

```swift
class First: UIView, SomeDelegate {
  let child: Child = {
    let child = Child()
    child.delegate = self
  }()
}
```

this pr prevent digging for already created `Identified` 