### PR TITLE
separate strong reference test from implementation tests

### DIFF
--- a/Tests/SwiftLayoutTests/ImplementationTests.swift
+++ b/Tests/SwiftLayoutTests/ImplementationTests.swift
@@ -56,40 +56,7 @@ extension ImplementationTests {
         
         XCTAssertEqual(expectedResult, result)
     }
-    
-    func testViewStrongReferenceCycle() {
-        class DeinitView: UIView {
-            static var deinitCount: Int = 0
-            
-            deinit {
-                Self.deinitCount += 1
-            }
-        }
-        
-        class SelfReferenceView: UIView, LayoutBuilding {
-            var layout: some Layout {
-                self {
-                    DeinitView().anchors {
-                        Anchors.allSides()
-                    }.sublayout {
-                        DeinitView()
-                    }
-                }
-            }
-            
-            var deactivable: Deactivable?
-        }
-        
-        DeinitView.deinitCount = 0
-        var view: SelfReferenceView? = SelfReferenceView()
-        weak var weakView: UIView? = view
-        
-        view?.updateLayout()
-        view = nil
-        
-        XCTAssertNil(weakView)
-        XCTAssertEqual(DeinitView.deinitCount, 2)
-    }
+   
     
     func testLayoutFlattening() {
         let layout = root {

--- a/Tests/SwiftLayoutTests/ReferenceTests.swift
+++ b/Tests/SwiftLayoutTests/ReferenceTests.swift
@@ -15,7 +15,6 @@ class ReferenceTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
     
     var view: SelfReferenceView?

--- a/Tests/SwiftLayoutTests/ReferenceTests.swift
+++ b/Tests/SwiftLayoutTests/ReferenceTests.swift
@@ -1,0 +1,60 @@
+//
+//  ReferenceTests.swift
+//  
+//
+//  Created by maylee on 2022/03/05.
+//
+
+import XCTest
+import SwiftLayout
+
+class ReferenceTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    var view: SelfReferenceView?
+    weak var weakView: UIView?
+    
+    func test1JustForPrepare() {
+        DeinitView.deinitCount = 0
+        view = SelfReferenceView()
+        weakView = view
+        
+        view?.updateLayout()
+        view?.layoutIfNeeded()
+        view = nil
+    }
+    
+    func test2ForReferenceReleasing() {
+        XCTAssertNil(weakView)
+        XCTAssertEqual(DeinitView.deinitCount, 2)
+    }
+    
+    class DeinitView: UIView {
+        static var deinitCount: Int = 0
+        
+        deinit {
+            Self.deinitCount += 1
+        }
+    }
+    
+    class SelfReferenceView: UIView, LayoutBuilding {
+        var layout: some Layout {
+            self {
+                DeinitView().anchors {
+                    Anchors.allSides()
+                }.sublayout {
+                    DeinitView()
+                }
+            }
+        }
+        
+        var deactivable: Deactivable?
+    }
+}


### PR DESCRIPTION
- `layoutIfNeeded` on view is prevent deinitializing of subviews on same code frame
- separate set up view state and testing