### PR TITLE
fix ambiguous use of Anchors.size

### DIFF
--- a/Sources/SwiftLayout/Core/Anchors/Anchors.swift
+++ b/Sources/SwiftLayout/Core/Anchors/Anchors.swift
@@ -556,11 +556,10 @@ public final class Anchors {
     ///
     /// - Parameters:
     ///  - toItem: constraint second item, ``ConstraintableItem``
-    ///  - length: constant
     ///
     /// - Returns: ``Anchors``
-    public static func size<I: ConstraintableItem>(_ toItem: I, offset: CGFloat = .zero) -> Anchors {
-        size(toItem, offset: CGSize(width: offset, height: offset))
+    public static func size<I: ConstraintableItem>(_ toItem: I) -> Anchors {
+        size(toItem, offset: .zero)
     }
     
     /// ``Anchors`` for width, height toward self
@@ -569,7 +568,7 @@ public final class Anchors {
     ///  - length: constant
     ///
     /// - Returns: ``Anchors``
-    public static func size(length: CGFloat = .zero) -> Anchors {
+    public static func size(length: CGFloat) -> Anchors {
         size(.init(width: length, height: length))
     }
     
@@ -580,7 +579,7 @@ public final class Anchors {
     ///  - size: constants
     ///
     /// - Returns: ``Anchors``
-    public static func size<I: ConstraintableItem>(_ toItem: I, offset: CGSize = .zero) -> Anchors {
+    public static func size<I: ConstraintableItem>(_ toItem: I, offset: CGSize) -> Anchors {
         let width = Anchors(.width).equalTo(toItem, constant: offset.width)
         let height = Anchors(.height).equalTo(toItem, constant: offset.height)
         return width.union(height)
@@ -592,7 +591,7 @@ public final class Anchors {
     ///  - size: constant
     ///
     /// - Returns: ``Anchors``
-    public static func size(_ size: CGSize = .zero) -> Anchors {
+    public static func size(_ size: CGSize) -> Anchors {
         let width = Anchors(.width).equalTo(constant: size.width)
         let height = Anchors(.height).equalTo(constant: size.height)
         return width.union(height)

--- a/Sources/SwiftLayout/Core/Anchors/Anchors.swift
+++ b/Sources/SwiftLayout/Core/Anchors/Anchors.swift
@@ -565,11 +565,23 @@ public final class Anchors {
     /// ``Anchors`` for width, height toward self
     ///
     /// - Parameters:
-    ///  - length: constant
+    ///  - length: constant, default value is 0.0
     ///
     /// - Returns: ``Anchors``
-    public static func size(length: CGFloat) -> Anchors {
+    public static func size(length: CGFloat = 0.0) -> Anchors {
         size(.init(width: length, height: length))
+    }
+    
+    /// ``Anchors`` for CGSize toward self
+    ///
+    /// - Parameters:
+    ///  - size: constant
+    ///
+    /// - Returns: ``Anchors``
+    public static func size(_ size: CGSize) -> Anchors {
+        let width = Anchors(.width).equalTo(constant: size.width)
+        let height = Anchors(.height).equalTo(constant: size.height)
+        return width.union(height)
     }
     
     /// ``Anchors`` for CGSize toward toItem: ``ConstraintableItem``
@@ -582,18 +594,6 @@ public final class Anchors {
     public static func size<I: ConstraintableItem>(_ toItem: I, offset: CGSize) -> Anchors {
         let width = Anchors(.width).equalTo(toItem, constant: offset.width)
         let height = Anchors(.height).equalTo(toItem, constant: offset.height)
-        return width.union(height)
-    }
-    
-    /// ``Anchors`` for CGSize toward self
-    ///
-    /// - Parameters:
-    ///  - size: constant
-    ///
-    /// - Returns: ``Anchors``
-    public static func size(_ size: CGSize) -> Anchors {
-        let width = Anchors(.width).equalTo(constant: size.width)
-        let height = Anchors(.height).equalTo(constant: size.height)
         return width.union(height)
     }
     

--- a/Tests/SwiftLayoutTests/PrintingTests.swift
+++ b/Tests/SwiftLayoutTests/PrintingTests.swift
@@ -361,6 +361,36 @@ extension PrintingTests {
         XCTAssertEqual(SwiftLayoutPrinter(root).print(), expect)
     }
     
+    func testPrintSize() {
+       
+        let root = UIView().viewTag.root
+        let child = UIView().viewTag.child
+        
+        func layout() -> some Layout {
+            root {
+                child.anchors {
+                    Anchors(.width, .height)
+                }
+            }
+        }
+        
+        layout().finalActive()
+        
+        XCTAssertEqual(root.constraints.shortDescription, """
+        child.width == root.width
+        child.height == root.height
+        """.descriptions)
+        
+        XCTAssertEqual(SwiftLayoutPrinter(root).print(), """
+        root {
+            child.anchors {
+                Anchors(.width, .height)
+            }
+        }
+        """.tabbed)
+        
+    }
+    
 }
 
 // MARK: - automatic identifier assignment


### PR DESCRIPTION
default parameter values for Anchors.size was meaningless.

 - second item

 - length: CGFloat

 - offset: CGSize

 - second item and offset

other cause ambiguous or misusing