### PR TITLE
no more tabbed on tests

### DIFF
--- a/Sources/SwiftLayoutUtil/Describe/Describer/ViewDescriber.swift
+++ b/Sources/SwiftLayoutUtil/Describe/Describer/ViewDescriber.swift
@@ -19,15 +19,15 @@ struct ViewDescriber {
                 descriptions.append(viewToken.viewTag)
             } else {
                 descriptions.append(viewToken.viewTag.appending(" {"))
-                descriptions.append(contentsOf: subdescribes.flatMap({ $0.descriptions(indents: "\t") }))
+                descriptions.append(contentsOf: subdescribes.flatMap({ $0.descriptions(indents: "    ") }))
                 descriptions.append("}")
             }
         } else {
             descriptions.append(viewToken.viewTag.appending(".anchors {"))
-            descriptions.append(contentsOf: AnchorsDescriber.descriptionFromConstraints(constraintTokens).map("\t".appending))
+            descriptions.append(contentsOf: AnchorsDescriber.descriptionFromConstraints(constraintTokens).map("    ".appending))
             if !subdescribes.isEmpty {
                 descriptions.append("}.sublayout {")
-                descriptions.append(contentsOf: subdescribes.flatMap({ $0.descriptions(indents: "\t") }))
+                descriptions.append(contentsOf: subdescribes.flatMap({ $0.descriptions(indents: "    ") }))
             }
             descriptions.append("}")
         }

--- a/Tests/SwiftLayoutUtilTests/Util/Extensions.swift
+++ b/Tests/SwiftLayoutUtilTests/Util/Extensions.swift
@@ -1,3 +1,0 @@
-extension String {
-    var tabbed: String { replacingOccurrences(of: "    ", with: "\t") }
-}

--- a/Tests/SwiftLayoutUtilTests/ViewPrinterTests.swift
+++ b/Tests/SwiftLayoutUtilTests/ViewPrinterTests.swift
@@ -31,7 +31,7 @@ extension ViewPrinterTests {
         root {
             child
         }
-        """.tabbed
+        """
         
         let result = ViewPrinter(root).description
         XCTAssertEqual(result, expect)
@@ -52,7 +52,7 @@ extension ViewPrinterTests {
             a
             b
         }
-        """.tabbed
+        """
         
         let result = ViewPrinter(root).description
         XCTAssertEqual(result, expect)
@@ -75,7 +75,7 @@ extension ViewPrinterTests {
                 grandchild
             }
         }
-        """.tabbed
+        """
         
         let result = ViewPrinter(root).description
         XCTAssertEqual(result, expect)
@@ -101,7 +101,7 @@ extension ViewPrinterTests {
             }
             friend
         }
-        """.tabbed
+        """
         let result = ViewPrinter(root).description
         XCTAssertEqual(result, expect)
     }
@@ -139,7 +139,7 @@ extension ViewPrinterTests {
                 Anchors.centerX.equalTo(one)
             }
         }
-        """.tabbed)
+        """)
     }
     
     func testSizeWithConstant() {
@@ -158,7 +158,7 @@ extension ViewPrinterTests {
                 Anchors.width.equalToSuper(constant: -20.0)
             }
         }
-        """.tabbed)
+        """)
     }
     
     func testPrintWithAnchorsWithOneDepth() {
@@ -180,7 +180,7 @@ extension ViewPrinterTests {
                 Anchors.bottom.equalToSuper(constant: -10.0)
             }
         }
-        """.tabbed
+        """
         
         let result = ViewPrinter(root).description
         XCTAssertEqual(result, expect)
@@ -212,7 +212,7 @@ extension ViewPrinterTests {
                 Anchors.top.equalTo(child, attribute: .bottom)
             }
         }
-        """.tabbed
+        """
         
         let result = ViewPrinter(root).description
         XCTAssertEqual(result, expect)
@@ -233,7 +233,7 @@ extension ViewPrinterTests {
                 Anchors.leading.trailing
             }
         }
-        """.tabbed
+        """
         
         let result = ViewPrinter(root).description
         
@@ -267,7 +267,7 @@ extension ViewPrinterTests {
                 }
             }
         }
-        """.tabbed
+        """
         
         let result = ViewPrinter(root).description
         XCTAssertEqual(result, expect)
@@ -294,7 +294,7 @@ extension ViewPrinterTests {
                 }
             }
         }
-        """.tabbed
+        """
         
         let result = ViewPrinter(root, tags: [child: "child", grand: "grandchild"]).description
         XCTAssertEqual(result, expect)
@@ -317,7 +317,7 @@ extension ViewPrinterTests {
                 Anchors.leading
             }
         }
-        """.tabbed
+        """
        
         let result = ViewPrinter(root).description
         
@@ -331,7 +331,7 @@ extension ViewPrinterTests {
             profileView:\(UIImageView.self)
             nameLabel:\(UILabel.self)
         }
-        """.tabbed
+        """
         
         let result = ViewPrinter(cell, tags: [cell: "contentView"]).updateIdentifiers(.withTypeOfView).description
         XCTAssertEqual(result, expect)
@@ -369,7 +369,7 @@ extension ViewPrinterTests {
                 Anchors.trailing.equalTo(child)
             }
         }
-        """.tabbed
+        """
         
         XCTAssertEqual(ViewPrinter(root).description, expect)
     }
@@ -402,7 +402,7 @@ extension ViewPrinterTests {
                 Anchors.height.equalTo(child)
             }
         }
-        """.tabbed
+        """
         
         XCTAssertEqual(ViewPrinter(root).description, expect)
     }
@@ -428,7 +428,7 @@ extension ViewPrinterTests {
                 Anchors.width.height.equalToSuper()
             }
         }
-        """.tabbed)
+        """)
         
     }
     
@@ -514,7 +514,7 @@ extension ViewPrinterTests {
                 }
             }
         }
-        """.tabbed)
+        """)
     }
     
     class Earth: UIView {
@@ -622,7 +622,7 @@ extension ViewPrinterTests {
                 Anchors.leading.trailing
             }
         }
-        """.tabbed)
+        """)
     }
     
 }
@@ -656,7 +656,7 @@ extension ViewPrinterTests {
                 }
             }
         }
-        """.tabbed
+        """
         
         XCTAssertEqual(
             ViewPrinter(container.root, options: .onlyIdentifier)


### PR DESCRIPTION
- removing tab character from result of view printer for users to use ViewPinter in their own tests
