### PR TITLE
Add more constraint method: startBracket endBracket (#256)

### DIFF
--- a/Sources/SwiftLayout/Core/Anchors/Anchors.swift
+++ b/Sources/SwiftLayout/Core/Anchors/Anchors.swift
@@ -110,6 +110,36 @@ public enum Anchors {
         return container
     }
     
+    /// combination of **top, leading, bottom** anchors for superview
+    ///
+    /// - Parameter offset: plus constant at top, plus constant at leading, minus constant at bottom. default value is 0.
+    /// - Returns:
+    /// superview.top + constant(offset)
+    /// **AND**
+    /// superview.leading + constant(offset) and superview.bottom - constant(offset)
+    public static func startBracket(offset: CGFloat = .zero) -> AnchorsContainer {
+        let container = AnchorsContainer()
+        container.append(AnchorsExpression(yAxis: .top).equalToSuper(constant: offset))
+        container.append(AnchorsExpression(xAxis: .leading).equalToSuper(constant: offset))
+        container.append(AnchorsExpression(xAxis: .bottom).equalToSuper(constant: -1.0 * offset))
+        return container
+    }
+    
+    /// combination of **top, trailing, bottom** anchors for superview
+    ///
+    /// - Parameter offset: plus constant at top, minus constant at trailing, minus constant at bottom. default value is 0.
+    /// - Returns:
+    /// superview.top + constant(offset)
+    /// **AND**
+    /// superview.trailing - constant(offset) and superview.bottom - constant(offset)
+    public static func endBracket(offset: CGFloat = .zero) -> AnchorsContainer {
+        let container = AnchorsContainer()
+        container.append(AnchorsExpression(yAxis: .top).equalToSuper(constant: offset))
+        container.append(AnchorsExpression(xAxis: .trailing).equalToSuper(constant: -1.0 * offset))
+        container.append(AnchorsExpression(xAxis: .bottom).equalToSuper(constant: -1.0 * offset))
+        return container
+    }
+    
     /// combination of **top, leading, trailing** anchors for superview
     ///
     /// - Parameter offset: plus constant at top, plus constant at leading, minus constant at trailing. default value is 0.


### PR DESCRIPTION
This commit provide two additional methods for the existing methods.
Start Bracket, End Bracket

Start Bracket can specify uniform constraints for top, leading, and bottom, as the name suggests.
End Bracket can specify uniform constraints for top, trailing, and bottom, as the name suggests.

The trailing and bottom are implemented to provide -1.0 multiples to apply the correct Offset.

Thank you.