### PR TITLE
Prevent unintended use and unexpected calls of config methods

### DIFF
--- a/Sources/SwiftLayout/Core/Layout/Layout.swift
+++ b/Sources/SwiftLayout/Core/Layout/Layout.swift
@@ -12,12 +12,16 @@ public protocol Layout {
     var anchors: Anchors { get }
     var sublayouts: [any Layout] { get }
     var option: LayoutOption? { get }
+
+    func layoutWillActivate()
 }
 
 extension Layout {
     public var view: UIView? { nil }
     public var anchors: Anchors { Anchors() }
     public var option: LayoutOption? { nil }
+
+    public func layoutWillActivate() {}
 }
 
 extension Layout {

--- a/Sources/SwiftLayout/Core/Layout/LayoutExplorer.swift
+++ b/Sources/SwiftLayout/Core/Layout/LayoutExplorer.swift
@@ -29,6 +29,8 @@ enum LayoutExplorer {
         var elements: [Component] = []
         
         traversal(layout: layout, superview: nil, option: .none) { layout, superview, option in
+            layout.layoutWillActivate()
+
             if let view = layout.view {
                 elements.append(Component(superView: superview, view: view, anchors: layout.anchors, option: option))
             }

--- a/Sources/SwiftLayout/Core/Layout/Layouts/ViewLayout.swift
+++ b/Sources/SwiftLayout/Core/Layout/Layouts/ViewLayout.swift
@@ -9,15 +9,23 @@ public struct ViewLayout<V: UIView>: Layout {
     public private(set) var anchors: Anchors
 
     public var option: LayoutOption? { LayoutOption.none }
+
+    typealias ConfigBlock = (V) -> Void
+    private let configBlock: ConfigBlock?
     
-    init(_ view: V, sublayouts: [any Layout] = [], anchors: Anchors = Anchors()) {
+    init(_ view: V, sublayouts: [any Layout] = [], anchors: Anchors = Anchors(), config: ConfigBlock? = nil) {
         self.innerView = view
         self.sublayouts = sublayouts
         self.anchors = anchors
+        self.configBlock = config
     }
     
     public var view: UIView? {
         self.innerView
+    }
+
+    public func layoutWillActivate() {
+        self.configBlock?(innerView)
     }
 }
 
@@ -52,7 +60,7 @@ extension ViewLayout {
     public func anchors(@AnchorsBuilder _ build: () -> Anchors) -> Self {
         let anchors = self.anchors
         anchors.append(build())
-        return Self.init(innerView, sublayouts: sublayouts, anchors: anchors)
+        return Self.init(innerView, sublayouts: sublayouts, anchors: anchors, config: configBlock)
     }
     
     ///
@@ -74,7 +82,7 @@ extension ViewLayout {
     public func sublayout<L: Layout>(@LayoutBuilder _ build: () -> L) -> Self {
         var sublayouts = self.sublayouts
         sublayouts.append(build())
-        return Self.init(innerView, sublayouts: sublayouts, anchors: anchors)
+        return Self.init(innerView, sublayouts: sublayouts, anchors: anchors, config: configBlock)
     }
     
     ///

--- a/Sources/SwiftLayout/Extension/UIVIew+Layout.swift
+++ b/Sources/SwiftLayout/Extension/UIVIew+Layout.swift
@@ -101,9 +101,8 @@ extension _UIViewExtension where Self: UIView {
     /// - Parameter config: A configuration block for this view.
     /// - Returns: The view itself with the configuration applied
     ///
-    public func config(_ config: (Self) -> Void) -> Self {
-        config(self)
-        return self
+    public func config(_ config: @escaping (Self) -> Void) -> ViewLayout<Self> {
+        return ViewLayout(self, config: config)
     }
     
     ///

--- a/Tests/SwiftLayoutTests/ImplementationTests/ImplementationTests.swift
+++ b/Tests/SwiftLayoutTests/ImplementationTests/ImplementationTests.swift
@@ -140,6 +140,95 @@ extension ImplementationTests {
         
         XCTAssertEqual(root.superview, old)
     }
+
+    func testConfigBlockCallOnlyOnceWithConstantLayout() {
+        let root = UIView().identifying("root")
+        let button: UIButton = UIButton().identifying("button")
+        let label: UILabel = UILabel().identifying("label")
+
+        var rootCount: Int = 0
+        var buttonCount: Int = 0
+        var labelCount: Int = 0
+
+        let layout: some Layout = root.config { _ in
+            rootCount += 1
+        }.sublayout {
+            button.config { _ in
+                buttonCount += 1
+            }
+
+            label.config { _ in
+                labelCount += 1
+            }
+        }
+
+        activation = layout.active()
+        XCTAssertEqual(rootCount, 1)
+        XCTAssertEqual(buttonCount, 1)
+        XCTAssertEqual(labelCount, 1)
+
+        activation = layout.update(fromActivation: activation!)
+        XCTAssertEqual(rootCount, 2)
+        XCTAssertEqual(buttonCount, 2)
+        XCTAssertEqual(labelCount, 2)
+
+        activation = layout.update(fromActivation: activation!)
+        XCTAssertEqual(rootCount, 3)
+        XCTAssertEqual(buttonCount, 3)
+        XCTAssertEqual(labelCount, 3)
+
+        activation?.deactive()
+        activation = nil
+        XCTAssertEqual(rootCount, 3)
+        XCTAssertEqual(buttonCount, 3)
+        XCTAssertEqual(labelCount, 3)
+    }
+
+    func testConfigBlockCallOnlyOnceWithComputedLayout() {
+        let root = UIView().identifying("root")
+        let button: UIButton = UIButton().identifying("button")
+        let label: UILabel = UILabel().identifying("label")
+
+        var rootCount: Int = 0
+        var buttonCount: Int = 0
+        var labelCount: Int = 0
+
+        var layout: some Layout {
+            root.config { _ in
+                rootCount += 1
+            }.sublayout {
+                button.config { _ in
+                    buttonCount += 1
+                }
+
+                label.config { _ in
+                    labelCount += 1
+                }
+            }
+        }
+
+        activation = layout.active()
+        XCTAssertEqual(rootCount, 1)
+        XCTAssertEqual(buttonCount, 1)
+        XCTAssertEqual(labelCount, 1)
+
+        var _ = layout
+        activation = layout.update(fromActivation: activation!)
+        XCTAssertEqual(rootCount, 2)
+        XCTAssertEqual(buttonCount, 2)
+        XCTAssertEqual(labelCount, 2)
+
+        activation = layout.update(fromActivation: activation!)
+        XCTAssertEqual(rootCount, 3)
+        XCTAssertEqual(buttonCount, 3)
+        XCTAssertEqual(labelCount, 3)
+
+        activation?.deactive()
+        activation = nil
+        XCTAssertEqual(rootCount, 3)
+        XCTAssertEqual(buttonCount, 3)
+        XCTAssertEqual(labelCount, 3)
+    }
 }
 
 extension ImplementationTests {

--- a/Tests/SwiftLayoutTests/ImplementationTests/ImplementationTests.swift
+++ b/Tests/SwiftLayoutTests/ImplementationTests/ImplementationTests.swift
@@ -304,12 +304,14 @@ extension ImplementationTests {
             }
         }
         
-        let stack = UIStackView().config { stack in
+        let stack: UIStackView = {
+            let stack = UIStackView()
             stack.axis = .vertical
             stack.distribution = .fillEqually
             stack.alignment = .center
             stack.spacing = 0.0
-        }.identifying("stack")
+            return stack
+        }().identifying("stack")
         
         let a = UIView().identifying("a")
         let b = UIView().identifying("b")


### PR DESCRIPTION
The current implementation of ```config(_:)``` is very simple and powerful. 
However, this implementation sometimes results in unintended execution of the config block passed to ```config(_:)```
Also, because of the powerful implementation, it can sometimes be used in unintended ways. 

I want to improve this by storing the config block in the ViewLayout and deferring the execution of the block to the activation phase.

**The problem**
If a user of an older version of the framework updates to a newer version and uses ```config(_:)``` as shown below, they will not receive compiler warnings, and may experience unintended results.

```Swift
// If the user uses 'config(:)' in this way, 
// the user will get a compiler error.
let label: UILabel = UILabel().config { label in
    ...
}


// If the user uses 'config(:)' in this way, 
// the label will be of type ViewLayout<UILabel> and will not generate a compiler error.
let label = UILabel().config { label in
    ...
}
```