### PR TITLE
Activation lifecycle

### DIFF
--- a/Sources/SwiftLayout/Core/Activator/Activator.swift
+++ b/Sources/SwiftLayout/Core/Activator/Activator.swift
@@ -15,6 +15,8 @@ enum Activator {
 
     @discardableResult
     static func update<L: Layout>(layout: L, fromActivation activation: Activation, forceLayout: Bool) -> Activation {
+        willActivate(layout: layout)
+
         let prevInfoHashValues = Set(activation.viewInfos.map(\.hashValue))
 
         let elements = LayoutElements(layout: layout)
@@ -29,12 +31,16 @@ enum Activator {
             layoutIfNeeded(viewInfos, prevInfoHashValues)
         }
 
+        didActivate(layout: layout)
+
         return activation
     }
 }
 
 extension Activator {
     public static func finalActive<L: Layout>(layout: L, forceLayout: Bool) {
+        willActivate(layout: layout)
+
         let elements = LayoutElements(layout: layout)
 
         let viewInfos = elements.viewInformations
@@ -46,10 +52,20 @@ extension Activator {
         if forceLayout {
             layoutIfNeeded(viewInfos)
         }
+
+        didActivate(layout: layout)
     }
 }
 
 private extension Activator {
+    static func willActivate<L: Layout>(layout: L) {
+        LayoutExplorer.traversal(layout: layout) { $0.layoutWillActivate() }
+    }
+
+    static func didActivate<L: Layout>(layout: L) {
+        LayoutExplorer.traversal(layout: layout) { $0.layoutDidActivate() }
+    }
+
     static func updateViews(activation: Activation, viewInfos: [ViewInformation]) {
         let newInfos = viewInfos
         let newInfosSet = Set(newInfos)

--- a/Sources/SwiftLayout/Core/Layout/Layout.swift
+++ b/Sources/SwiftLayout/Core/Layout/Layout.swift
@@ -14,6 +14,7 @@ public protocol Layout {
     var option: LayoutOption? { get }
 
     func layoutWillActivate()
+    func layoutDidActivate()
 }
 
 extension Layout {
@@ -22,6 +23,7 @@ extension Layout {
     public var option: LayoutOption? { nil }
 
     public func layoutWillActivate() {}
+    public func layoutDidActivate() {}
 }
 
 extension Layout {

--- a/Sources/SwiftLayout/Core/Layout/LayoutExplorer.swift
+++ b/Sources/SwiftLayout/Core/Layout/LayoutExplorer.swift
@@ -29,14 +29,22 @@ enum LayoutExplorer {
         var elements: [Component] = []
         
         traversal(layout: layout, superview: nil, option: .none) { layout, superview, option in
-            layout.layoutWillActivate()
-
-            if let view = layout.view {
-                elements.append(Component(superView: superview, view: view, anchors: layout.anchors, option: option))
+            guard let view = layout.view else {
+                return
             }
+
+            elements.append(Component(superView: superview, view: view, anchors: layout.anchors, option: option))
         }
         
         return elements
+    }
+
+    static func traversal(layout: any Layout, handler: (any Layout) -> Void) {
+        handler(layout)
+
+        layout.sublayouts.forEach { layout in
+            traversal(layout: layout, handler: handler)
+        }
     }
     
     static func traversal(layout: any Layout, superview: UIView?, option: LayoutOption, handler: TraversalHandler) {


### PR DESCRIPTION
I changed the lifecycle method of layout to be called using the traversal method of LayoutExplorer.

This change requires 2 additional traversals, and I'm worried that this will have a negative impact on activation speed. What do you think?