### PR TITLE
Use SwiftLint only during the development phase.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,28 +11,32 @@ let package = Package(
             targets: ["SwiftLayout"]
         )
     ],
-    dependencies: [
-        .package(
-            url: "https://github.com/realm/SwiftLint.git",
-            exact: "0.55.1"
-        )
-    ],
     targets: [
         .target(
             name: "SwiftLayout",
-            dependencies: [],
-            plugins: [
-                .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")
-            ]
+            dependencies: []
         ),
         .testTarget(
             name: "SwiftLayoutTests",
             dependencies: [
                 "SwiftLayout"
-            ],
-            plugins: [
-                .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")
             ]
         )
     ]
 )
+
+private let useSwiftLint = false
+
+if useSwiftLint {
+    package.dependencies += [
+        .package(
+            url: "https://github.com/realm/SwiftLint.git",
+            exact: "0.55.1"
+        )
+    ]
+    for target in package.targets {
+        target.plugins = [
+            .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")
+        ]
+    }
+}


### PR DESCRIPTION
Adopting SwiftLint as a dependency introduces eight additional packages, including swift-syntax, which are unnecessary for SwiftLayout users. The swift-syntax package, in particular, could cause build failures depending on how Swift macros are applied.

To resolve this, I propose modifying the setup to use SwiftLint only during development by enabling it with a flag.

However, since I couldn’t find a way to automatically detect the development environment, this solution is currently implemented as a local value.