### PR TITLE
Removed layout deactivation from Activation deinit due to crash issue

### DIFF
--- a/Sources/SwiftLayout/Core/Activator/Activation.swift
+++ b/Sources/SwiftLayout/Core/Activator/Activation.swift
@@ -19,15 +19,6 @@ public final class Activation: Hashable {
         self.viewInfos = viewInfos
         self.constraints = constraints
     }
-
-    deinit {
-        let views = self.viewInfos.compactMap(\.view)
-        let constraints = self.constraints
-
-        Task { @MainActor in
-            Deactivator().deactivate(views: views, constraints: constraints)
-        }
-    }
 }
 
 extension Activation {

--- a/Sources/SwiftLayout/Core/Activator/Activator.swift
+++ b/Sources/SwiftLayout/Core/Activator/Activator.swift
@@ -9,12 +9,10 @@ import UIKit
 
 @MainActor
 enum Activator {
-
     static func active<L: Layout>(layout: L, forceLayout: Bool = false) -> Activation {
         return update(layout: layout, fromActivation: Activation(), forceLayout: forceLayout)
     }
 
-    @discardableResult
     static func update<L: Layout>(layout: L, fromActivation activation: Activation, forceLayout: Bool) -> Activation {
         willActivate(layout: layout)
 
@@ -39,7 +37,7 @@ enum Activator {
 }
 
 extension Activator {
-    public static func finalActive<L: Layout>(layout: L, forceLayout: Bool) {
+    static func finalActive<L: Layout>(layout: L, forceLayout: Bool) {
         willActivate(layout: layout)
 
         let elements = LayoutElements(layout: layout)

--- a/Sources/SwiftLayout/Core/Layout/Layout.swift
+++ b/Sources/SwiftLayout/Core/Layout/Layout.swift
@@ -32,7 +32,7 @@ extension Layout {
     ///
     /// Activate this layout.
     ///
-    /// - Returns: A ``Activation`` instance, which you use when you update or deactivate layout. Deallocation of the result will deactivate layout.
+    /// - Returns: A ``Activation`` instance, which you use when you update or deactivate layout. 
     ///
     public func active(forceLayout: Bool = false) -> Activation {
         Activator.active(layout: self, forceLayout: forceLayout)
@@ -42,7 +42,7 @@ extension Layout {
     /// Update layout changes from the activation of the previously activated layout.
     ///
     /// - Parameter activation: The activation of the previously activated layout. It is used to identify changes in layout.
-    /// - Returns: A ``Activation`` instance, which you use when you update or deactivate layout. Deallocation of the result will deactivate layout.
+    /// - Returns: A ``Activation`` instance, which you use when you update or deactivate layout.
     ///
     public func update(fromActivation activation: Activation, forceLayout: Bool = false) -> Activation {
         Activator.update(layout: self, fromActivation: activation, forceLayout: forceLayout)

--- a/Tests/SwiftLayoutTests/InterfaceTests/AnchorsDSLTests.swift
+++ b/Tests/SwiftLayoutTests/InterfaceTests/AnchorsDSLTests.swift
@@ -94,7 +94,7 @@ struct AnchorsDSLTests { // swiftlint:disable:this type_body_length
             }
 
             func deactivate() async {
-                activation = nil
+                activation?.deactive()
             }
 
             func expectation() async {


### PR DESCRIPTION
- Previously, layout deactivation was performed during Activation's deinitialization.
- This implicit behavior caused a crash due to unsafe view access when the view hierarchy was already invalid.
- Removed the view-handling logic from the deinit to prevent such crashes.
- Layout deactivation must now be handled explicitly outside of the Activation lifecycle.